### PR TITLE
use nvr host for rtsp stream

### DIFF
--- a/pyunifiprotect/unifi_protect_server.py
+++ b/pyunifiprotect/unifi_protect_server.py
@@ -309,7 +309,7 @@ class UpvServer:
                         channels = camera["channels"]
                         for channel in channels:
                             if channel["isRtspEnabled"]:
-                                rtsp = f"rtsp://{camera['connectionHost']}:7447/{channel['rtspAlias']}"
+                                rtsp = f"rtsp://{self._host}:7447/{channel['rtspAlias']}"
                                 break
 
                         item = {


### PR DESCRIPTION
I'm not sure what causes this, but one of my cameras was using my public IP instead of the NVR hostname/ip for RTSP streams. This ensures the proper ip/hostname is set when streaming via RTSP by setting it to the NVR.

I don't believe there to be any negative side effects of this change, as I believe all RTSP streams are routed through the NVR and not direct to the camera.