### PR TITLE
Skip cameras that are not present in the state machine

### DIFF
--- a/pyunifiprotect/unifi_protect_server.py
+++ b/pyunifiprotect/unifi_protect_server.py
@@ -939,7 +939,7 @@ class UpvServer:  # pylint: disable=too-many-public-methods, too-many-instance-a
             self._camera_state_machine, self._host, action_json, data_json
         )
 
-        if camera_id is None or processed_camera is None:
+        if camera_id is None:
             return
         _LOGGER.debug("Processed camera: %s", processed_camera)
 


### PR DESCRIPTION
I added `has_camera` to the state machine so we can skip cameras that aren't present.