### PR TITLE
 Only clear the event_object if smartDetectEvents is not set in the followup motion event

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/pyunifiprotect/unifi_data.py
+++ b/pyunifiprotect/unifi_data.py
@@ -665,8 +665,14 @@ def process_event(event, minimum_score, ring_interval):
         "event_start": start_time,
         "event_length": event_length,
         "event_score": score,
-        "event_object": event.get("smartDetectTypes"),
     }
+
+    if smart_detect_types := event.get("smartDetectTypes"):
+        processed_event["event_object"] = smart_detect_types
+    elif not event.get("smartDetectEvents"):
+        # Only clear the event_object if smartDetectEvents
+        # is not set in the followup motion event
+        processed_event["event_object"] = None
 
     if event_type in (EVENT_MOTION, EVENT_SMART_DETECT_ZONE):
         processed_event["last_motion"] = start_time

--- a/pyunifiprotect/unifi_protect_server.py
+++ b/pyunifiprotect/unifi_protect_server.py
@@ -104,7 +104,7 @@ class UpvServer:  # pylint: disable=too-many-public-methods, too-many-instance-a
 
     @property
     def devices(self):
-        """ Returns a JSON formatted list of Devices. """
+        """Returns a JSON formatted list of Devices."""
         return self._processed_data
 
     async def update(self, force_camera_update=False) -> dict:
@@ -537,7 +537,7 @@ class UpvServer:  # pylint: disable=too-many-public-methods, too-many-instance-a
             return await response.read()
 
     async def get_snapshot_image(self, camera_id: str) -> bytes:
-        """ Returns a Snapshot image of a recording event. """
+        """Returns a Snapshot image of a recording event."""
 
         await self.ensure_authenticated()
 


### PR DESCRIPTION
Maybe fixes https://github.com/briis/unifiprotect/issues/225