### PR TITLE
Refactors packet code

### DIFF
--- a/pyunifiprotect/__init__.py
+++ b/pyunifiprotect/__init__.py
@@ -1,10 +1,6 @@
 """Python Wrapper for Unifi Protect."""
-from pyunifiprotect.unifi_protect_server import (
-    Invalid,
-    NotAuthorized,
-    NvrError,
-    UpvServer,
-)
+from .exceptions import Invalid, NotAuthorized, NvrError
+from .unifi_protect_server import UpvServer
 
 __all__ = [
     "Invalid",

--- a/pyunifiprotect/__main__.py
+++ b/pyunifiprotect/__main__.py
@@ -2,7 +2,7 @@ import os
 
 from dotenv import load_dotenv
 
-from pyunifiprotect.cli import app
+from .cli import app
 
 
 def start():

--- a/pyunifiprotect/cli.py
+++ b/pyunifiprotect/cli.py
@@ -7,7 +7,7 @@ from aiohttp import ClientSession, CookieJar
 from traitlets.config import get_config
 import typer
 
-from pyunifiprotect.unifi_protect_server import _LOGGER, UpvServer
+from .unifi_protect_server import _LOGGER, UpvServer
 
 try:
     from IPython import embed

--- a/pyunifiprotect/exceptions.py
+++ b/pyunifiprotect/exceptions.py
@@ -1,0 +1,22 @@
+class UnifiProtectError(Exception):
+    """Base class for all other Unifi Protect errors"""
+
+
+class WSDecodeError(UnifiProtectError):
+    """Exception raised when decoding Websocket packet"""
+
+
+class ClientError(UnifiProtectError):
+    """Base Class for all other Unifi Protect client errors"""
+
+
+class Invalid(ClientError):
+    """Invalid return from Authorization Request."""
+
+
+class NotAuthorized(ClientError):
+    """Wrong username and/or Password."""
+
+
+class NvrError(ClientError):
+    """Other error."""

--- a/pyunifiprotect/unifi_data.py
+++ b/pyunifiprotect/unifi_data.py
@@ -844,7 +844,7 @@ class WSRawPacketFrame:
             packet_type, payload_format, deflated, unknown, payload_size = struct.unpack(
                 "!bbbbi", data[position:header_end]
             )
-        except Exception as e:
+        except struct.error as e:
             raise WSDecodeError from e
 
         if klass is None:

--- a/pyunifiprotect/unifi_data.py
+++ b/pyunifiprotect/unifi_data.py
@@ -949,29 +949,3 @@ class WSPacket:
             self._raw_encoded = base64.b64encode(self._raw).decode("utf-8")
 
         return self._raw_encoded
-
-    def _update_frame(self, frame: WSPacketFrameHeader, new_data: Any):
-        if frame.payload_format != ProtectWSPayloadFormat.JSON:
-            raise UnifiProtectError("Can only update JSON packets")
-
-        new_raw = json.dumps(new_data).encode("utf-8")
-
-        if self.action_frame.is_deflated:
-            new_raw = zlib.compress(new_raw)
-
-        new_header = struct.pack(
-            "!bbbbi",
-            frame.header.packet_type,
-            frame.header.payload_format,
-            frame.header.delated,
-            frame.header.unknown,
-            len(new_raw),
-        )
-
-        return new_header + new_raw
-
-    def update_packet(self, action_frame: Any, data_frame: Any):
-        new_action_frame = self._update_frame(self.action_frame, action_frame)
-        new_data_frame = self._update_frame(self.data_frame, data_frame)
-
-        self._raw = new_action_frame + new_data_frame

--- a/pyunifiprotect/unifi_data.py
+++ b/pyunifiprotect/unifi_data.py
@@ -11,10 +11,10 @@ import json
 import logging
 import struct
 import time
-from typing import Any, Optional, Type
+from typing import Optional, Type
 import zlib
 
-from .exceptions import UnifiProtectError, WSDecodeError
+from .exceptions import WSDecodeError
 
 WS_HEADER_SIZE = 8
 _LOGGER = logging.getLogger(__name__)

--- a/pyunifiprotect/unifi_data.py
+++ b/pyunifiprotect/unifi_data.py
@@ -848,7 +848,7 @@ class WSRawPacketFrame:
             raise WSDecodeError from e
 
         if klass is None:
-            frame = WSRawPacketFrame.klass_from_format(payload_format)
+            frame = WSRawPacketFrame.klass_from_format(payload_format)()
         else:
             frame = klass()
             frame.payload_format = ProtectWSPayloadFormat(payload_format)

--- a/tests/test_unifi_protect_server.py
+++ b/tests/test_unifi_protect_server.py
@@ -1,14 +1,42 @@
 """Tests for pyunifi_protect_server."""
 
-import aiohttp
+import base64
+import json
+
 import pytest
 
-from .unifi_protect_server import UpvServer
+from pyunifiprotect.unifi_data import ProtectWSPayloadFormat, decode_ws_frame
+from pyunifiprotect.unifi_protect_server import UpvServer
+
+PACKET_B64 = b"AQEBAAAAAHR4nB2MQQrCMBBFr1JmbSDNpJnRG4hrDzBNZqCgqUiriHh3SZb/Pd7/guRtWSucBtgfRTaFwwBV39c+zqUJskQW1DufUVwkJsfFxDGLyRFj0dSz+1r0dtFPa+rr2dDSD8YsyceUpskQxzjjHIIQMvz+hMoj/AIBAQAAAAA1eJyrViotKMnMTVWyUjA0MjawMLQ0MDDQUVDKSSwuCU5NzQOJmxkbACUszE0sLQ1rAVU/DPU="
+PACKET_ACTION = {
+    "action": "update",
+    "newUpdateId": "7f67f2e0-0c3a-4787-8dfa-88afa934de6e",
+    "modelKey": "nvr",
+    "id": "1ca6046655f3314b3b22a738",
+}
+PACKET_DATA = {"uptime": 1230819000, "lastSeen": 1630081874991}
+
+
+def test_decode_frame():
+    packet_raw = base64.b64decode(PACKET_B64)
+
+    raw_data, payload_format, position = decode_ws_frame(packet_raw, 0)
+
+    assert json.loads(raw_data) == PACKET_ACTION
+    assert payload_format == ProtectWSPayloadFormat.JSON
+    assert position == 124
+
+    raw_data, payload_format, position = decode_ws_frame(packet_raw, position)
+
+    assert json.loads(raw_data) == PACKET_DATA
+    assert payload_format == ProtectWSPayloadFormat.JSON
+    assert position == 185
 
 
 @pytest.mark.asyncio
 async def test_upvserver_creation():
     """Test we can create the object."""
 
-    upv = UpvServer(aiohttp.ClientSession(), "127.0.0.1", 0, "username", "password")
+    upv = UpvServer(None, "127.0.0.1", 0, "username", "password")
     assert upv

--- a/tests/test_unifi_protect_server.py
+++ b/tests/test_unifi_protect_server.py
@@ -3,7 +3,7 @@
 import aiohttp
 import pytest
 
-from pyunifiprotect.unifi_protect_server import UpvServer
+from .unifi_protect_server import UpvServer
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
* Removes all exceptions to new module `pyunifiprotect.exceptions`
* Adds new base classes for exceptions
* Cleans up imports from `pyunifiprotect` to be relative
* Adds new class enum `ModelType` to for `modelKey` values
* Adds refactors decoding of packets from Unifi Protect into new classes: `WSPacketFrameHeader`, `WSPacketFrame`, and `WSPacket`
    * These classes will give a more structured approach to handling packets from Protect
    * Basic support for updating/creating new Protect packets
* Adds a test to make sure `decode_ws_frame` stays consistent / working