### PR TITLE
Adds missing pytest env for tox

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+env:
+  DEFAULT_PYTHON: 3.9
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,18 +15,32 @@ jobs:
         python-version: [3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
+
     - name: Check black with tox
-      run: TOXENV=black tox
+      if: ${{ matrix.python-version == env.DEFAULT_PYTHON }}
+      run: tox -e black
+
     - name: Check isort tox
-      run: TOXENV=isort tox
+      if: ${{ matrix.python-version == env.DEFAULT_PYTHON }}
+      run: tox -e isort
+
     - name: Lint with tox
-      run: TOXENV=lint tox
+      if: ${{ matrix.python-version == env.DEFAULT_PYTHON }}
+      run: tox -e lint
+
+    - name: Run Tests
+      run: |
+        PY_VERSION=${{ matrix.python-version }}
+        tox -e py${PY_VERSION/./}


### PR DESCRIPTION
* Updates `lint` / `black` / `isort` job steps to only run on Python 3.9 since that is how tox is configured
* Adds `py38` / `py39` tox env runs