### PR TITLE
Switch time.time -> time.monotonic

### DIFF
--- a/pyunifiprotect/unifi_protect_server.py
+++ b/pyunifiprotect/unifi_protect_server.py
@@ -370,7 +370,7 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
     async def update(self, force_camera_update=False) -> dict:
         """Updates the status of devices."""
 
-        current_time = time.time()
+        current_time = time.monotonic()
         device_update = False
         if (
             not self.ws_connection


### PR DESCRIPTION
`_last_device_update_time` and `_last_websocket_check` are actually used as reference points since the last time we did something rather then absolute markers in time. So `time.monotonic` is actually what is wanted here since we absoltely do not want time to move backwards on us.

`time.time` is actually subject to NTP updates. So you could call `time.time` twice in a row and get a time before the one you got when you previously called it.

`time.monotonic` never changes. It will always "X second python has been running".

https://docs.python.org/3/library/time.html#time.monotonic