### PR TITLE
Improves determining reason for bad responses

### DIFF
--- a/pyunifiprotect/test_util/__init__.py
+++ b/pyunifiprotect/test_util/__init__.py
@@ -128,7 +128,11 @@ class SampleDataGenerator:
 
         return data
 
-    def write_image_file(self, name: str, raw: bytes):
+    def write_image_file(self, name: str, raw: Optional[bytes]):
+        if raw is None:
+            typer.echo(f"No image data, skipping {name}...")
+            return
+
         typer.echo(f"Writing {name}...")
         with open(self.output_folder / f"{name}.png", "wb") as f:
             f.write(raw)

--- a/pyunifiprotect/unifi_protect_server.py
+++ b/pyunifiprotect/unifi_protect_server.py
@@ -353,7 +353,7 @@ class BaseApiClient:
         log = _LOGGER.warning
 
         if self._websocket_failures < 10 or (now - self._websocket_error_start) < WEBSOCKET_ERROR_GRACE_PERIOD:
-            log = _LOGGER.info
+            log = _LOGGER.debug
         log("Unifi OS: Websocket connection not active, failing back to polling")
 
     def _process_ws_message(self, msg):

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -1,3 +1,4 @@
+import contextlib
 from datetime import datetime
 from typing import Any, Dict, Optional
 
@@ -15,7 +16,7 @@ async def get_response_reason(response: ClientResponse) -> str:
         json = await response.json()
         reason = json.get("error", str(json))
     except Exception:  # pylint: disable=broad-except
-        with contextlib.suppress(Exception):  # pylint: disable=broad-except
+        with contextlib.suppress(Exception):
             reason = await response.text()
 
     return reason

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -15,10 +15,8 @@ async def get_response_reason(response: ClientResponse) -> str:
         json = await response.json()
         reason = json.get("error", str(json))
     except Exception:  # pylint: disable=broad-except
-        try:
+        with contextlib.suppress(Exception):  # pylint: disable=broad-except
             reason = await response.text()
-        except Exception:  # pylint: disable=broad-except
-            pass
 
     return reason
 

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -1,9 +1,26 @@
 from datetime import datetime
 from typing import Any, Dict, Optional
 
+from aiohttp import ClientResponse
+
 from pyunifiprotect.unifi_data import StateType
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+async def get_response_reason(response: ClientResponse) -> str:
+    reason = str(response.reason)
+
+    try:
+        json = await response.json()
+        reason = json.get("error", str(json))
+    except Exception:  # pylint: disable=broad-except
+        try:
+            reason = await response.text()
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+    return reason
 
 
 def to_js_time(dt) -> int:


### PR DESCRIPTION
* Adds new method to try to retrieve error from response body when there is a bad error code instead of always using `response.reason`, which will always be the "name" of the HTTP status code (500 = Internal Server Error, 400 = Bad Request, etc.)
* Handles error response in `write_image_file` for generating sample data