### PR TITLE
Adds support for no CSRF token from UnifiOS

### DIFF
--- a/pyunifiprotect/unifi_protect_server.py
+++ b/pyunifiprotect/unifi_protect_server.py
@@ -207,9 +207,13 @@ class BaseApiClient:
 
         response = await self.request("post", url=url, json=auth)
         self.headers = {
-            "x-csrf-token": response.headers.get("x-csrf-token"),
             "cookie": response.headers.get("set-cookie"),
         }
+
+        csrf_token = response.headers.get("x-csrf-token")
+        if csrf_token is not None:
+            self.headers["x-csrf-token"] = csrf_token
+
         self._is_authenticated = True
         _LOGGER.debug("Authenticated successfully!")
 


### PR DESCRIPTION
If you are using `pyunifiprotect` _on_ the same physical machine as your UnifiOS console, UnifiOS does not provide a CSRF token. `aiohttp` cannot handle a header with a `NoneType` so this should exclude the CSRF token if it is not being provided by UnifiOS.

Fixes https://github.com/briis/pyunifiprotect/issues/33 and https://github.com/briis/unifiprotect/issues/312

## HA Install Link:

```
git+https://github.com/AngellusMortis/pyunifiprotect.git@feature/no-csrf-token#pyunifiprotect==0.35.3
```