### PR TITLE
Fixes dictionary is empty error when trying to remove item from FixSizeOrderedDict

### DIFF
--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -1,11 +1,10 @@
-from collections import OrderedDict
 import enum
 from typing import List, Optional
 
 from pydantic import ConstrainedDecimal, ConstrainedInt
 
 
-class FixSizeOrderedDict(OrderedDict):
+class FixSizeOrderedDict(dict):
     """A fixed size ordered dict."""
 
     def __init__(self, *args, max_size=0, **kwargs):
@@ -16,9 +15,8 @@ class FixSizeOrderedDict(OrderedDict):
     def __setitem__(self, key, value):
         """Set an update up to the max size."""
         dict.__setitem__(self, key, value)
-        if self._max_size > 0:
-            if len(self) > self._max_size:
-                self.popitem(False)
+        if self._max_size > 0 and len(self) > 0 and len(self) > self._max_size:
+            del self[list(self.keys())[0]]
 
 
 class ValuesEnumMixin:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,6 +3,8 @@
 import base64
 from copy import deepcopy
 
+import pytest
+
 from pyunifiprotect.data import (
     Bootstrap,
     Camera,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,6 +7,7 @@ from pyunifiprotect.data import (
     Bootstrap,
     Camera,
     Event,
+    FixSizeOrderedDict,
     Light,
     ModelType,
     ProtectModel,
@@ -140,3 +141,26 @@ def test_bootstrap(bootstrap):
             compare_objs(expected["modelKey"], expected, actual)
 
     assert bootstrap == obj_dict
+
+
+def test_fix_order_size_dict_max():
+    d = FixSizeOrderedDict(max_size=1)
+    d["test"] = 1
+    d["test2"] = 2
+    d["test3"] = 3
+
+    with pytest.raises(KeyError):
+        del d["test2"]
+
+    assert d == {"test3": 3}
+
+
+def test_fix_order_size_dict_negative_max():
+    d = FixSizeOrderedDict(max_size=-1)
+    d["test"] = 1
+    d["test2"] = 2
+    d["test3"] = 3
+
+    del d["test2"]
+
+    assert d == {"test": 1, "test3": 3}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -143,6 +143,17 @@ def test_bootstrap(bootstrap):
     assert bootstrap == obj_dict
 
 
+def test_fix_order_size_dict_no_max():
+    d = FixSizeOrderedDict()
+    d["test"] = 1
+    d["test2"] = 2
+    d["test3"] = 3
+
+    del d["test2"]
+
+    assert d == {"test": 1, "test3": 3}
+
+
 def test_fix_order_size_dict_max():
     d = FixSizeOrderedDict(max_size=1)
     d["test"] = 1

--- a/tests/test_unifi_data.py
+++ b/tests/test_unifi_data.py
@@ -3,7 +3,9 @@
 import base64
 import json
 
-from pyunifiprotect.data import ProtectWSPayloadFormat
+import pytest
+
+from pyunifiprotect.data import FixSizeOrderedDict, ProtectWSPayloadFormat
 from pyunifiprotect.unifi_data import decode_ws_frame
 
 PACKET_B64 = b"AQEBAAAAAHR4nB2MQQrCMBBFr1JmbSDNpJnRG4hrDzBNZqCgqUiriHh3SZb/Pd7/guRtWSucBtgfRTaFwwBV39c+zqUJskQW1DufUVwkJsfFxDGLyRFj0dSz+1r0dtFPa+rr2dDSD8YsyceUpskQxzjjHIIQMvz+hMoj/AIBAQAAAAA1eJyrViotKMnMTVWyUjA0MjawMLQ0MDDQUVDKSSwuCU5NzQOJmxkbACUszE0sLQ1rAVU/DPU="
@@ -30,3 +32,37 @@ def test_decode_frame():
     assert json.loads(raw_data) == PACKET_DATA
     assert payload_format == ProtectWSPayloadFormat.JSON
     assert position == 185
+
+
+def test_fix_order_size_dict_no_max():
+    d = FixSizeOrderedDict()
+    d["test"] = 1
+    d["test2"] = 2
+    d["test3"] = 3
+
+    del d["test2"]
+
+    assert d == {"test": 1, "test3": 3}
+
+
+def test_fix_order_size_dict_max():
+    d = FixSizeOrderedDict(max_size=1)
+    d["test"] = 1
+    d["test2"] = 2
+    d["test3"] = 3
+
+    with pytest.raises(KeyError):
+        del d["test2"]
+
+    assert d == {"test3": 3}
+
+
+def test_fix_order_size_dict_negative_max():
+    d = FixSizeOrderedDict(max_size=-1)
+    d["test"] = 1
+    d["test2"] = 2
+    d["test3"] = 3
+
+    del d["test2"]
+
+    assert d == {"test": 1, "test3": 3}

--- a/tests/test_unifi_data.py
+++ b/tests/test_unifi_data.py
@@ -3,9 +3,7 @@
 import base64
 import json
 
-import pytest
-
-from pyunifiprotect.data import FixSizeOrderedDict, ProtectWSPayloadFormat
+from pyunifiprotect.data import ProtectWSPayloadFormat
 from pyunifiprotect.unifi_data import decode_ws_frame
 
 PACKET_B64 = b"AQEBAAAAAHR4nB2MQQrCMBBFr1JmbSDNpJnRG4hrDzBNZqCgqUiriHh3SZb/Pd7/guRtWSucBtgfRTaFwwBV39c+zqUJskQW1DufUVwkJsfFxDGLyRFj0dSz+1r0dtFPa+rr2dDSD8YsyceUpskQxzjjHIIQMvz+hMoj/AIBAQAAAAA1eJyrViotKMnMTVWyUjA0MjawMLQ0MDDQUVDKSSwuCU5NzQOJmxkbACUszE0sLQ1rAVU/DPU="
@@ -32,37 +30,3 @@ def test_decode_frame():
     assert json.loads(raw_data) == PACKET_DATA
     assert payload_format == ProtectWSPayloadFormat.JSON
     assert position == 185
-
-
-def test_fix_order_size_dict_no_max():
-    d = FixSizeOrderedDict()
-    d["test"] = 1
-    d["test2"] = 2
-    d["test3"] = 3
-
-    del d["test2"]
-
-    assert d == {"test": 1, "test3": 3}
-
-
-def test_fix_order_size_dict_max():
-    d = FixSizeOrderedDict(max_size=1)
-    d["test"] = 1
-    d["test2"] = 2
-    d["test3"] = 3
-
-    with pytest.raises(KeyError):
-        del d["test2"]
-
-    assert d == {"test3": 3}
-
-
-def test_fix_order_size_dict_negative_max():
-    d = FixSizeOrderedDict(max_size=-1)
-    d["test"] = 1
-    d["test2"] = 2
-    d["test3"] = 3
-
-    del d["test2"]
-
-    assert d == {"test": 1, "test3": 3}


### PR DESCRIPTION
Fixes:

```
2021-10-30 00:36:57 ERROR (MainThread) [pyunifiprotect.unifi_protect_server] Error processing websocket message
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/pyunifiprotect/unifi_protect_server.py", line 282, in _setup_websocket
    self._process_ws_message(msg)
  File "/usr/local/lib/python3.9/site-packages/pyunifiprotect/unifi_protect_server.py", line 949, in _process_ws_message
    self._process_event_ws_message(action_json, data_json)
  File "/usr/local/lib/python3.9/site-packages/pyunifiprotect/unifi_protect_server.py", line 1018, in _process_event_ws_message
    device_id, processed_event = event_from_ws_frames(
  File "/usr/local/lib/python3.9/site-packages/pyunifiprotect/unifi_data.py", line 466, in event_from_ws_frames
    state_machine.add(event_id, data_json)
  File "/usr/local/lib/python3.9/site-packages/pyunifiprotect/unifi_data.py", line 772, in add
    self._events[event_id] = event_json
  File "/usr/local/lib/python3.9/site-packages/pyunifiprotect/data/types.py", line 19, in __setitem__
    self.popitem(False)
KeyError: 'dictionary is empty'
```

I am guessing this started happening after python 3.7 when `dict` / `OrderedDict` were changed to ensure order. `popitem` just does not seem to work as expected. So I changed it to a normal dict (which py3.7+ are promised to be ordered) and I just del the first key now.

Added some tests to ensure the functionality of the class.

## HA Install Link:

```
git+https://github.com/AngellusMortis/pyunifiprotect.git@bugfix/fix-size-dict#pyunifiprotect==0.35.3
```
