### PR TITLE
Enforces strict mypy type checking

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,29 @@
 # Waiting for next version of pydantic before moving to pyproject.toml
 # https://github.com/samuelcolvin/pydantic/issues/2895
 [mypy]
+python_version = 3.10
+warn_unused_configs = true
 plugins = pydantic.mypy
 disable_error_code = no-redef
+exclude = dist
+
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true
+no_implicit_reexport = true
+strict_equality = true
+implicit_reexport = true
+
+[mypy-tests.*]
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+check_untyped_defs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ good-names = [
 # wrong-import-order - isort guards this
 # no-member - mypy handles this better
 # unsupported-membership-test - mypy handles this better
+# unsubscriptable-object - mypy handles this better
 disable = [
     "format",
     "abstract-class-little-used",
@@ -117,6 +118,7 @@ disable = [
     "fixme",
     "no-member",
     "unsupported-membership-test",
+    "unsubscriptable-object",
 ]
 enable = [
     #"useless-suppression",  # temporarily every now and then to clean them up

--- a/pyunifiprotect/__main__.py
+++ b/pyunifiprotect/__main__.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 from pyunifiprotect.cli import app
 
 
-def start():
+def start() -> None:
     env_file = os.path.join(os.getcwd(), ".env")
     if os.path.exists(env_file):
         load_dotenv(dotenv_path=env_file)

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from pyunifiprotect.unifi_protect_server import ProtectApiClient
 
 
-T = TypeVar("T", bound="ProtectBaseObject ")
+T = TypeVar("T", bound="ProtectBaseObject")
 
 
 class ProtectBaseObject(BaseModel):
@@ -35,12 +35,12 @@ class ProtectBaseObject(BaseModel):
     _initial_data: Dict[str, Any] = PrivateAttr()
 
     UNIFI_REMAP: ClassVar[Dict[str, str]] = {}
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {}
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {}  # type: ignore
 
     class Config:
         arbitrary_types_allowed = True
 
-    def __init__(self, api=None, **data: Any) -> None:
+    def __init__(self, api: Optional[ProtectApiClient] = None, **data: Any) -> None:
         data["api"] = api
         data = self.clean_unifi_dict(data)
         super().__init__(**data)

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -614,7 +614,7 @@ class SensorStats(ProtectBaseObject):
     humidity: SensorStat
     temperature: SensorStat
 
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
         "light": SensorStat,
         "humidity": SensorStat,
         "temperature": SensorStat,
@@ -642,7 +642,7 @@ class Sensor(ProtectAdoptableDeviceModel):
     # TODO:
     # mountType
 
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
         "alarmSettings": SensorSettingsBase,
         "batteryStatus": SensorBatteryStatus,
     }

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -70,7 +70,7 @@ class Light(ProtectMotionDeviceModel):
     is_camera_paired: bool
 
     UNIFI_REMAP: ClassVar[Dict[str, str]] = {**ProtectMotionDeviceModel.UNIFI_REMAP, **{"camera": "cameraId"}}
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
         "lightDeviceSettings": LightDeviceSettings,
         "lightOnSettings": LightOnSettings,
         "lightModeSettings": LightModeSettings,
@@ -105,7 +105,7 @@ class CameraEventStats(ProtectBaseObject):
     motion: EventStats
     smart: EventStats
 
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
         "motion": EventStats,
         "smart": EventStats,
     }
@@ -356,7 +356,7 @@ class CameraStats(ProtectBaseObject):
     wifi_quality: PercentInt
     wifi_strength: int
 
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
         "wifi": WifiStats,
         "battery": BatteryStats,
         "video": VideoStats,
@@ -450,7 +450,7 @@ class FeatureFlags(ProtectBaseObject):
     # zoom
 
     UNIFI_REMAP: ClassVar[Dict[str, str]] = {"hasAutoICROnly": "hasAutoIcrOnly"}
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {"privacyMaskCapability": PrivacyMaskCapability}
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {"privacyMaskCapability": PrivacyMaskCapability}  # type: ignore
 
 
 class Camera(ProtectMotionDeviceModel):
@@ -508,7 +508,7 @@ class Camera(ProtectMotionDeviceModel):
     last_smart_detect: Optional[datetime] = None
     last_smart_detect_event_id: Optional[str] = None
 
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
         "eventStats": CameraEventStats,
         "ispSettings": ISPSettings,
         "talkbackSettings": TalkbackSettings,

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -133,7 +133,7 @@ class CloudAccount(ProtectModelWithId):
             "user": "userId",
         },
     }
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {"location": UserLocation}
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {"location": UserLocation}  # type: ignore
 
     def unifi_dict(self, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         data = super().unifi_dict(data=data)
@@ -177,7 +177,7 @@ class User(ProtectModelWithId):
     # notificationsV2
 
     UNIFI_REMAP: ClassVar[Dict[str, str]] = {**ProtectModelWithId.UNIFI_REMAP, **{"groups": "groupIds"}}
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
         "location": UserLocation,
         "cloudAccount": CloudAccount,
     }
@@ -271,7 +271,7 @@ class SystemInfo(ProtectBaseObject):
     storage: StorageInfo
     tmpfs: TMPFSInfo
 
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
         "memory": MemoryInfo,
         "storage": StorageInfo,
         "tmpfs": TMPFSInfo,
@@ -325,7 +325,7 @@ class StorageStats(ProtectBaseObject):
     recording_space: StorageSpace
     storage_distribution: StorageDistribution
 
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
         "recordingSpace": StorageSpace,
     }
 
@@ -391,7 +391,7 @@ class NVR(ProtectDeviceModel):
         **ProtectDeviceModel.UNIFI_REMAP,
         **{"recordingRetentionDurationMs": "recordingRetentionDuration"},
     }
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
         "ports": PortConfig,
         "locationSettings": NVRLocation,
         "featureFlags": NVRFeatureFlags,
@@ -492,7 +492,7 @@ class Bootstrap(ProtectBaseObject):
     # chimes
     # schedules
 
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {
+    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
         "nvr": NVR,
     }
 
@@ -524,9 +524,10 @@ class Bootstrap(ProtectBaseObject):
 
     @property
     def auth_user(self) -> User:
-        return self._api.bootstrap.users[self.auth_user_id]
+        user: User = self._api.bootstrap.users[self.auth_user_id]
+        return user
 
-    def process_event(self, event: Event):
+    def process_event(self, event: Event) -> None:
         if event.camera is None:
             return
 
@@ -548,7 +549,7 @@ class Bootstrap(ProtectBaseObject):
 
         self.events[event.id] = event
 
-    def process_ws_packet(self, packet: WSPacket):
+    def process_ws_packet(self, packet: WSPacket) -> None:
         if not isinstance(packet.action_frame, WSJSONPacketFrame):
             _LOGGER.debug("Unexpected action frame format: %s", packet.action_frame.payload_format)
 

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -12,7 +12,7 @@ VT = TypeVar("VT")
 # TODO: Remove when 3.8 support is dropped
 if TYPE_CHECKING:
 
-    class FixSizeOrderedDictBase(dict[KT, VT]):  # pylint: disable=unsubscriptable-object
+    class FixSizeOrderedDictBase(dict[KT, VT]):
         pass
 
 

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import enum
-from typing import Any, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, List, Optional, TypeVar
 
 from pydantic import ConstrainedDecimal, ConstrainedInt
 
@@ -7,7 +9,20 @@ KT = TypeVar("KT")
 VT = TypeVar("VT")
 
 
-class FixSizeOrderedDict(dict[KT, VT]):
+# TODO: Remove when 3.8 support is dropped
+if TYPE_CHECKING:
+
+    class FixSizeOrderedDictBase(dict[KT, VT]):  # pylint: disable=unsubscriptable-object
+        pass
+
+
+else:
+
+    class FixSizeOrderedDictBase(Generic[KT, VT], OrderedDict):
+        pass
+
+
+class FixSizeOrderedDict(FixSizeOrderedDictBase[KT, VT]):
     """A fixed size ordered dict."""
 
     def __init__(self, *args: Any, max_size: int = 0, **kwargs: Any) -> None:

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -1,18 +1,21 @@
 import enum
-from typing import List, Optional
+from typing import Any, List, Optional, TypeVar
 
 from pydantic import ConstrainedDecimal, ConstrainedInt
 
+KT = TypeVar("KT")
+VT = TypeVar("VT")
 
-class FixSizeOrderedDict(dict):
+
+class FixSizeOrderedDict(dict[KT, VT]):
     """A fixed size ordered dict."""
 
-    def __init__(self, *args, max_size=0, **kwargs):
+    def __init__(self, *args: Any, max_size: int = 0, **kwargs: Any) -> None:
         """Create the FixSizeOrderedDict."""
         self._max_size = max_size
         super().__init__(*args, **kwargs)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: KT, value: VT) -> None:
         """Set an update up to the max size."""
         dict.__setitem__(self, key, value)
         if self._max_size > 0 and len(self) > 0 and len(self) > self._max_size:

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 else:
 
-    class FixSizeOrderedDictBase(Generic[KT, VT], OrderedDict):
+    class FixSizeOrderedDictBase(Generic[KT, VT], dict):
         pass
 
 

--- a/pyunifiprotect/exceptions.py
+++ b/pyunifiprotect/exceptions.py
@@ -10,6 +10,10 @@ class WSDecodeError(UnifiProtectError):
     """Exception raised when decoding Websocket packet"""
 
 
+class WSEncodeError(UnifiProtectError):
+    """Exception raised when encoding Websocket packet"""
+
+
 class ClientError(UnifiProtectError):
     """Base Class for all other Unifi Protect client errors"""
 

--- a/pyunifiprotect/test_util/__init__.py
+++ b/pyunifiprotect/test_util/__init__.py
@@ -67,6 +67,7 @@ class SampleDataGenerator:
         self.constants["server_name"] = bootstrap["nvr"]["name"]
         self.constants["server_id"] = bootstrap["nvr"]["mac"]
         self.constants["server_version"] = bootstrap["nvr"]["version"]
+        self.constants["server_ip"] = bootstrap["nvr"]["host"]
         self.constants["last_update_id"] = bootstrap["lastUpdateId"]
         self.constants["user_id"] = bootstrap["authUserId"]
         self.constants["counts"] = {

--- a/pyunifiprotect/test_util/__init__.py
+++ b/pyunifiprotect/test_util/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import datetime
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from PIL import Image
 import aiohttp
@@ -22,7 +22,7 @@ from pyunifiprotect.unifi_protect_server import UpvServer
 SLEEP_INTERVAL = 2
 
 
-def placeholder_image(output_path: Path, width: int, height: Optional[int] = None):
+def placeholder_image(output_path: Path, width: int, height: Optional[int] = None) -> None:
     if height is None:
         height = width
 
@@ -36,25 +36,25 @@ class SampleDataGenerator:
     _record_num_ws: int = 0
     _record_ws_start_time: datetime = datetime.now()
     _record_listen_for_events: bool = False
-    _record_ws_messages: Dict[str, dict] = {}
+    _record_ws_messages: Dict[str, Dict[str, Any]] = {}
 
-    constants: dict = {}
+    constants: Dict[str, Any] = {}
     client: UpvServer
     output_folder: Path
     anonymize: bool
     wait_time: int
 
-    def __init__(self, client: UpvServer, output: Path, anonymize: bool, wait_time: int):
+    def __init__(self, client: UpvServer, output: Path, anonymize: bool, wait_time: int) -> None:
         self.client = client
         self.output_folder = output
         self.anonymize = anonymize
         self.wait_time = wait_time
 
-    def generate(self):
+    def generate(self) -> None:
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.async_generate())
 
-    async def async_generate(self, close_session=True):
+    async def async_generate(self, close_session: bool = True) -> None:
         typer.echo(f"Output folder: {self.output_folder}")
         self.output_folder.mkdir(parents=True, exist_ok=True)
         self.client.ws_callback = self._handle_ws_message
@@ -62,31 +62,30 @@ class SampleDataGenerator:
         typer.echo("Updating devices...")
         await self.client.update(True)
 
-        data = await self.client.api_request("bootstrap")
-        data = self.write_json_file("sample_bootstrap", data)
-        self.constants["server_name"] = data["nvr"]["name"]
-        self.constants["server_id"] = data["nvr"]["mac"]
-        self.constants["server_version"] = data["nvr"]["version"]
-        self.constants["server_ip"] = data["nvr"]["host"]
-        self.constants["last_update_id"] = data["lastUpdateId"]
-        self.constants["user_id"] = data["authUserId"]
+        bootstrap: Dict[str, Any] = await self.client.api_request_obj("bootstrap")
+        bootstrap = self.write_json_file("sample_bootstrap", bootstrap)  # type: ignore
+        self.constants["server_name"] = bootstrap["nvr"]["name"]
+        self.constants["server_id"] = bootstrap["nvr"]["mac"]
+        self.constants["server_version"] = bootstrap["nvr"]["version"]
+        self.constants["last_update_id"] = bootstrap["lastUpdateId"]
+        self.constants["user_id"] = bootstrap["authUserId"]
         self.constants["counts"] = {
-            "camera": len(data["cameras"]),
-            "user": len(data["users"]),
-            "group": len(data["groups"]),
-            "liveview": len(data["liveviews"]),
-            "viewer": len(data["viewers"]),
-            "display": len(data["displays"]),
-            "light": len(data["lights"]),
-            "bridge": len(data["bridges"]),
-            "sensor": len(data["sensors"]),
-            "doorlock": len(data["doorlocks"]),
-            "chime": len(data["chimes"]),
-            "schedule": len(data["schedules"]),
+            "camera": len(bootstrap["cameras"]),
+            "user": len(bootstrap["users"]),
+            "group": len(bootstrap["groups"]),
+            "liveview": len(bootstrap["liveviews"]),
+            "viewer": len(bootstrap["viewers"]),
+            "display": len(bootstrap["displays"]),
+            "light": len(bootstrap["lights"]),
+            "bridge": len(bootstrap["bridges"]),
+            "sensor": len(bootstrap["sensors"]),
+            "doorlock": len(bootstrap["doorlocks"]),
+            "chime": len(bootstrap["chimes"]),
+            "schedule": len(bootstrap["schedules"]),
         }
 
-        data = await self.client.api_request("liveviews")
-        data = self.write_json_file("sample_liveviews", data)
+        liveviews: List[Any] = await self.client.api_request_list("liveviews")
+        liveviews = self.write_json_file("sample_liveviews", liveviews)  # type: ignore
 
         await self.record_ws_events()
         heatmap_event = await self.generate_event_data()
@@ -97,7 +96,7 @@ class SampleDataGenerator:
 
         self.write_json_file("sample_constants", self.constants, anonymize=False)
 
-    async def record_ws_events(self):
+    async def record_ws_events(self) -> None:
         if self.wait_time <= 0:
             typer.echo("Skipping recording Websocket messages...")
             return
@@ -116,7 +115,9 @@ class SampleDataGenerator:
         await self.client.async_disconnect_ws()
         self.write_json_file("sample_ws_messages", self._record_ws_messages, anonymize=False)
 
-    def write_json_file(self, name: str, data: dict, anonymize: Optional[bool] = None):
+    def write_json_file(
+        self, name: str, data: Union[List[Any], Dict[str, Any]], anonymize: Optional[bool] = None
+    ) -> Union[List[Any], Dict[str, Any]]:
         if anonymize is None:
             anonymize = self.anonymize
 
@@ -130,7 +131,7 @@ class SampleDataGenerator:
 
         return data
 
-    def write_image_file(self, name: str, raw: Optional[bytes]):
+    def write_image_file(self, name: str, raw: Optional[bytes]) -> None:
         if raw is None:
             typer.echo(f"No image data, skipping {name}...")
             return
@@ -139,14 +140,14 @@ class SampleDataGenerator:
         with open(self.output_folder / f"{name}.png", "wb") as f:
             f.write(raw)
 
-    async def generate_event_data(self):
+    async def generate_event_data(self) -> Optional[Dict[str, Any]]:
         data = await self.client.get_raw_events()
         heatmap_event = None
         for event in data:
             if event.get("heatmap") is not None and event.get("type") in EventType.motion_events():
-                heatmap_event = event
+                heatmap_event: Dict[str, Any] = event
 
-        data = self.write_json_file("sample_raw_events", data)
+        data = self.write_json_file("sample_raw_events", data)  # type: ignore
         self.constants["time"] = datetime.now().isoformat()
         self.constants["event_count"] = len(data)
 
@@ -154,7 +155,7 @@ class SampleDataGenerator:
         await self.client._get_events()
         return heatmap_event
 
-    async def generate_device_data(self, camera_heatmap_event: Optional[Dict[str, Any]]):
+    async def generate_device_data(self, camera_heatmap_event: Optional[Dict[str, Any]]) -> None:
         has_heatmap = False
         is_camera_online = False
         camera_id: Optional[str] = None
@@ -205,7 +206,7 @@ class SampleDataGenerator:
         else:
             await self.generate_viewport_data(viewport_id)
 
-    async def generate_camera_data(self, camera_id: str, heatmap_event: Optional[Dict[str, Any]]):
+    async def generate_camera_data(self, camera_id: str, heatmap_event: Optional[Dict[str, Any]]) -> None:
         filename = "sample_camera_thumbnail"
         thumbnail = self.client.devices[camera_id]["event_thumbnail"]
         if thumbnail is None:
@@ -230,7 +231,7 @@ class SampleDataGenerator:
             self.write_image_file(filename, await self.client.get_snapshot_image(camera_id=camera_id))
 
         data = await self.client._get_camera_detail(camera_id=camera_id)
-        data = self.write_json_file("sample_camera", data)
+        data = self.write_json_file("sample_camera", data)  # type: ignore
 
         if heatmap_event is not None:
             self.client._process_events([heatmap_event], LIVE_RING_FROM_WEBSOCKET)
@@ -247,15 +248,15 @@ class SampleDataGenerator:
             if img is not None:
                 self.write_image_file("sample_camera_heatmap", img)
 
-    async def generate_light_data(self, light_id: str):
+    async def generate_light_data(self, light_id: str) -> None:
         data = await self.client._get_light_detail(light_id=light_id)
-        data = self.write_json_file("sample_light", data)
+        data = self.write_json_file("sample_light", data)  # type: ignore
 
-    async def generate_viewport_data(self, viewport_id: str):
+    async def generate_viewport_data(self, viewport_id: str) -> None:
         data = await self.client._get_viewport_detail(viewport_id=viewport_id)
-        data = self.write_json_file("sample_viewport", data)
+        data = self.write_json_file("sample_viewport", data)  # type: ignore
 
-    def _handle_ws_message(self, msg: aiohttp.WSMessage):
+    def _handle_ws_message(self, msg: aiohttp.WSMessage) -> None:
         if not self._record_listen_for_events:
             return
 

--- a/pyunifiprotect/test_util/__init__.py
+++ b/pyunifiprotect/test_util/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import datetime
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional, overload
+from typing import Any, Dict, List, Optional, Union, overload
 
 from PIL import Image
 import aiohttp
@@ -121,6 +121,11 @@ class SampleDataGenerator:
 
     @overload
     def write_json_file(self, name: str, data: Dict[str, Any], anonymize: Optional[bool] = None) -> Dict[str, Any]:
+        ...
+
+    def write_json_file(
+        self, name: str, data: Union[List[Any], Dict[str, Any]], anonymize: Optional[bool] = None
+    ) -> Union[List[Any], Dict[str, Any]]:
         if anonymize is None:
             anonymize = self.anonymize
 

--- a/pyunifiprotect/test_util/anonymize.py
+++ b/pyunifiprotect/test_util/anonymize.py
@@ -11,7 +11,7 @@ from pyunifiprotect.unifi_data import ModelType
 object_id_mapping: Dict[str, str] = {}
 
 
-def anonymize_data(value: Any, name: Optional[str] = None):
+def anonymize_data(value: Any, name: Optional[str] = None) -> Any:
     if isinstance(value, list):
         value = anonymize_list(value, name=name)
     elif isinstance(value, dict):
@@ -22,7 +22,7 @@ def anonymize_data(value: Any, name: Optional[str] = None):
     return value
 
 
-def anonymize_user(user_dict: dict) -> dict:
+def anonymize_user(user_dict: Dict[str, Any]) -> Dict[str, Any]:
     for index, group_id in enumerate(user_dict.get("groups", [])):
         user_dict["groups"][index] = anonymize_object_id(group_id)
 
@@ -58,7 +58,7 @@ def anonymize_user(user_dict: dict) -> dict:
     return user_dict
 
 
-def anonymize_value(value: Any, name: Optional[str] = None):
+def anonymize_value(value: Any, name: Optional[str] = None) -> Any:
     if isinstance(value, str):
         if name == "accessKey":
             value = f"{random_number(13)}:{random_hex(24)}:{random_hex(128)}"
@@ -83,7 +83,7 @@ def anonymize_value(value: Any, name: Optional[str] = None):
     return value
 
 
-def anonymize_dict(obj: dict, name: Optional[str] = None) -> dict:
+def anonymize_dict(obj: Dict[str, Any], name: Optional[str] = None) -> Dict[str, Any]:
     obj_type = None
     if "modelKey" in obj:
         if obj["modelKey"] in [m.value for m in ModelType]:
@@ -110,7 +110,7 @@ def anonymize_dict(obj: dict, name: Optional[str] = None) -> dict:
     return obj
 
 
-def anonymize_list(items: List, name: Optional[str] = None) -> List:
+def anonymize_list(items: List[Any], name: Optional[str] = None) -> List[Any]:
     for index, value in enumerate(items):
         handled = False
 
@@ -135,7 +135,7 @@ def anonymize_prefixed_event_id(event_id: str) -> str:
     return f"e-{anonymize_object_id(event_id)}"
 
 
-def anonymize_ip(ip: Any):
+def anonymize_ip(ip: Any) -> Any:
     if not isinstance(ip, str):
         return ip
 
@@ -153,7 +153,7 @@ def anonymize_object_id(obj_id: str) -> str:
     return anonymize_peristent_string(obj_id, random_hex(24))
 
 
-def anonymize_peristent_string(value: str, default: str):
+def anonymize_peristent_string(value: str, default: str) -> str:
     if value not in object_id_mapping:
         object_id_mapping[value] = default
 

--- a/pyunifiprotect/unifi_data.py
+++ b/pyunifiprotect/unifi_data.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 import logging
 import time
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple, Union
 
 from pyunifiprotect.data import (
     EventType,
@@ -12,6 +12,7 @@ from pyunifiprotect.data import (
     ModelType,
     WSRawPacketFrame,
 )
+from pyunifiprotect.data.types import ProtectWSPayloadFormat
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -105,14 +106,14 @@ SENSOR_KEYS = {
 VIEWPORT_KEYS = {"liveview", "online"}
 
 
-def decode_ws_frame(frame, position):
+def decode_ws_frame(frame: bytes, position: int) -> Tuple[bytes, ProtectWSPayloadFormat, int]:
     """Decode a unifi updates websocket frame."""
 
     frame_obj = WSRawPacketFrame.from_binary(frame, position, klass=WSRawPacketFrame)
     return frame_obj.data, frame_obj.payload_format, position + frame_obj.length
 
 
-def process_viewport(server_id, viewport, include_events):
+def process_viewport(server_id: Optional[str], viewport: Dict[str, Any], include_events: bool) -> Dict[str, Any]:
     """Process the viewport json."""
 
     # Get if Viewport is Online
@@ -142,7 +143,7 @@ def process_viewport(server_id, viewport, include_events):
     return viewport_update
 
 
-def process_light(server_id, light, include_events):
+def process_light(server_id: Optional[str], light: Dict[str, Any], include_events: bool) -> Dict[str, Any]:
     """Process the light json."""
 
     # Get if Light is Online
@@ -158,12 +159,12 @@ def process_light(server_id, light, include_events):
         else datetime.datetime.fromtimestamp(int(light["upSince"]) / 1000).strftime("%Y-%m-%d %H:%M:%S")
     )
     # Get Light Mode Settings
-    lightmodesettings = light.get("lightModeSettings")
+    lightmodesettings = light.get("lightModeSettings", {})
     motion_mode = lightmodesettings.get("mode")
     motion_mode_enabled_at = lightmodesettings.get("enableAt")
     # Get Light Device Setting
     device_type = light["modelKey"]
-    lightdevicesettings = light.get("lightDeviceSettings")
+    lightdevicesettings = light.get("lightDeviceSettings", {})
     brightness = lightdevicesettings.get("ledLevel")
     lux_sensitivity = lightdevicesettings.get("luxSensitivity")
     pir_duration = lightdevicesettings.get("pirDuration")
@@ -202,7 +203,7 @@ def process_light(server_id, light, include_events):
     return light_update
 
 
-def process_sensor(server_id, sensor, include_events):
+def process_sensor(server_id: Optional[str], sensor: Dict[str, Any], include_events: bool) -> Dict[str, Any]:
     """Process the sensor json."""
 
     device_type = sensor["modelKey"]
@@ -217,7 +218,7 @@ def process_sensor(server_id, sensor, include_events):
         else datetime.datetime.fromtimestamp(int(sensor["upSince"]) / 1000).strftime("%Y-%m-%d %H:%M:%S")
     )
     # Get Sensor Status
-    stats = sensor.get("stats")
+    stats = sensor.get("stats", {})
     light_value = stats["light"]["value"]
     humidity_value = stats["humidity"]["value"]
     temperature_value = stats["temperature"]["value"]
@@ -275,7 +276,7 @@ def process_sensor(server_id, sensor, include_events):
     return sensor_update
 
 
-def process_camera(server_id, host, camera, include_events):
+def process_camera(server_id: Optional[str], host: str, camera: Dict[str, Any], include_events: bool) -> Dict[str, Any]:
     """Process the camera json."""
 
     # If addtional keys are checked, update CAMERA_KEYS
@@ -301,7 +302,7 @@ def process_camera(server_id, host, camera, include_events):
     firmware_version = str(camera["firmwareVersion"])
 
     # Get High FPS Video Mode
-    featureflags = camera.get("featureFlags")
+    featureflags = camera.get("featureFlags", {})
     has_highfps = "highFps" in featureflags.get("videoModes", "")
     video_mode = camera.get("videoMode") or "default"
     # Get HDR Mode
@@ -420,7 +421,9 @@ def process_camera(server_id, host, camera, include_events):
     return camera_update
 
 
-def event_from_ws_frames(state_machine, minimum_score, action_json, data_json):
+def event_from_ws_frames(
+    state_machine: ProtectEventStateMachine, minimum_score: int, action_json: Dict[str, Any], data_json: Dict[str, Any]
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
     """Convert a websocket frame to internal format.
 
     Smart Detect Event Add:
@@ -459,7 +462,7 @@ def event_from_ws_frames(state_machine, minimum_score, action_json, data_json):
         if device_id is None:
             return None, None
         state_machine.add(event_id, data_json)
-        event = data_json
+        event: Optional[Dict[str, Any]] = data_json
     elif action == "update":
         event = state_machine.update(event_id, data_json)
         if not event:
@@ -469,12 +472,16 @@ def event_from_ws_frames(state_machine, minimum_score, action_json, data_json):
         raise ValueError("The action must be add or update")
 
     _LOGGER.debug("Processing event: %s", event)
-    processed_event = process_event(event, minimum_score, LIVE_RING_FROM_WEBSOCKET)
+    processed_event: Optional[Dict[str, Any]] = None
+    if event is not None:
+        processed_event = process_event(event, minimum_score, LIVE_RING_FROM_WEBSOCKET)
 
     return device_id, processed_event
 
 
-def sensor_update_from_ws_frames(state_machine, action_json, data_json):
+def sensor_update_from_ws_frames(
+    state_machine: ProtectDeviceStateMachine, action_json: Dict[str, Any], data_json: Dict[str, Any]
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
     """Convert a websocket frame to internal format."""
 
     if action_json["modelKey"] != "sensor":
@@ -498,7 +505,9 @@ def sensor_update_from_ws_frames(state_machine, action_json, data_json):
     return sensor_id, processed_sensor
 
 
-def light_update_from_ws_frames(state_machine, action_json, data_json):
+def light_update_from_ws_frames(
+    state_machine: ProtectDeviceStateMachine, action_json: Dict[str, Any], data_json: Dict[str, Any]
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
     """Convert a websocket frame to internal format."""
 
     if action_json["modelKey"] != "light":
@@ -522,7 +531,9 @@ def light_update_from_ws_frames(state_machine, action_json, data_json):
     return light_id, processed_light
 
 
-def camera_update_from_ws_frames(state_machine, host, action_json, data_json):
+def camera_update_from_ws_frames(
+    state_machine: ProtectDeviceStateMachine, host: str, action_json: Dict[str, Any], data_json: Dict[str, Any]
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
     """Convert a websocket frame to internal format."""
 
     if action_json["modelKey"] != "camera":
@@ -546,15 +557,17 @@ def camera_update_from_ws_frames(state_machine, host, action_json, data_json):
     return camera_id, processed_camera
 
 
-def camera_event_from_ws_frames(state_machine, action_json, data_json):
+def camera_event_from_ws_frames(
+    state_machine: ProtectDeviceStateMachine, action_json: Dict[str, Any], data_json: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
     """Create processed events from the camera model."""
 
     if "isMotionDetected" not in data_json and "lastMotion" not in data_json:
         return None
 
     camera_id = action_json["id"]
-    start_time = None
-    event_length = 0
+    start_time: Optional[Union[str, int]] = None
+    event_length: float = 0
     event_on = False
 
     last_motion = data_json.get("lastMotion")
@@ -586,7 +599,9 @@ def camera_event_from_ws_frames(state_machine, action_json, data_json):
     }
 
 
-def light_event_from_ws_frames(state_machine, action_json, data_json):
+def light_event_from_ws_frames(
+    state_machine: ProtectDeviceStateMachine, action_json: Dict[str, Any], data_json: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
     """Create processed events from the light model."""
 
     if "isPirMotionDetected" not in data_json and "lastMotion" not in data_json:
@@ -594,7 +609,7 @@ def light_event_from_ws_frames(state_machine, action_json, data_json):
 
     light_id = action_json["id"]
     start_time = None
-    event_length = 0
+    event_length: float = 0
     event_on = False
     _LOGGER.debug("Processed light event: %s", data_json)
 
@@ -627,7 +642,9 @@ def light_event_from_ws_frames(state_machine, action_json, data_json):
     }
 
 
-def sensor_event_from_ws_frames(state_machine, action_json, data_json):
+def sensor_event_from_ws_frames(
+    state_machine: ProtectDeviceStateMachine, action_json: Dict[str, Any], data_json: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
     """Create processed events from the sensor model."""
     # TODO: Add the events that can occur (Motion and Door Open/Close)
     if "isPirMotionDetected" not in data_json and "lastMotion" not in data_json:
@@ -635,7 +652,7 @@ def sensor_event_from_ws_frames(state_machine, action_json, data_json):
 
     light_id = action_json["id"]
     start_time = None
-    event_length = 0
+    event_length: float = 0
     event_on = False
     _LOGGER.debug("Processed light event: %s", data_json)
 
@@ -668,14 +685,14 @@ def sensor_event_from_ws_frames(state_machine, action_json, data_json):
     }
 
 
-def process_event(event, minimum_score, ring_interval):
+def process_event(event: Dict[str, Any], minimum_score: int, ring_interval: int) -> Dict[str, Any]:
     """Convert an event to our format."""
     start = event.get("start")
     end = event.get("end")
     event_type = event.get("type")
     score = event.get("score")
 
-    event_length = 0
+    event_length: float = 0
     start_time = None
 
     if start:
@@ -725,32 +742,35 @@ def process_event(event, minimum_score, ring_interval):
     return processed_event
 
 
-def _process_timestamp(time_stamp):
+def _process_timestamp(time_stamp: Union[str, int]) -> str:
     return datetime.datetime.fromtimestamp(int(time_stamp) / 1000).strftime("%Y-%m-%d %H:%M:%S")
 
 
 class ProtectDeviceStateMachine:
     """A simple state machine for events."""
 
-    def __init__(self):
+    _devices: Dict[str, Dict[str, Any]]
+    _motion_detected_time: Dict[str, Optional[Union[str, int]]]
+
+    def __init__(self) -> None:
         """Init the state machine."""
         self._devices = {}
         self._motion_detected_time = {}
 
-    def has_device(self, device_id):
+    def has_device(self, device_id: str) -> bool:
         """Check to see if a device id is in the state machine."""
         return device_id in self._devices
 
-    def update(self, device_id, new_json):
+    def update(self, device_id: str, new_json: Dict[str, Any]) -> Dict[str, Any]:
         """Update an device in the state machine."""
         self._devices.setdefault(device_id, {}).update(new_json)
         return self._devices[device_id]
 
-    def set_motion_detected_time(self, device_id, timestamp):
+    def set_motion_detected_time(self, device_id: str, timestamp: Optional[Union[str, int]]) -> None:
         """Set device motion start detected time."""
         self._motion_detected_time[device_id] = timestamp
 
-    def get_motion_detected_time(self, device_id):
+    def get_motion_detected_time(self, device_id: str) -> Optional[Union[str, int]]:
         """Get device motion start detected time."""
         return self._motion_detected_time.get(device_id)
 
@@ -758,15 +778,17 @@ class ProtectDeviceStateMachine:
 class ProtectEventStateMachine:
     """A simple state machine for cameras."""
 
-    def __init__(self):
+    _events: FixSizeOrderedDict[str, Dict[str, Any]]
+
+    def __init__(self) -> None:
         """Init the state machine."""
         self._events = FixSizeOrderedDict(max_size=MAX_EVENT_HISTORY_IN_STATE_MACHINE)
 
-    def add(self, event_id, event_json):
+    def add(self, event_id: str, event_json: Dict[str, Any]) -> None:
         """Add an event to the state machine."""
         self._events[event_id] = event_json
 
-    def update(self, event_id, new_event_json):
+    def update(self, event_id: str, new_event_json: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Update an event in the state machine and return the merged event."""
         event_json = self._events.get(event_id)
         if event_json is None:

--- a/pyunifiprotect/unifi_protect_server.py
+++ b/pyunifiprotect/unifi_protect_server.py
@@ -5,13 +5,12 @@ from datetime import datetime, timedelta
 import json as pjson
 import logging
 import time
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
 from urllib.parse import urljoin
 from uuid import UUID
 
 import aiohttp
 from aiohttp import client_exceptions
-from aiohttp.client import _WSRequestContextManager
 import jwt
 from yarl import URL
 
@@ -82,11 +81,11 @@ class BaseApiClient:
     _websocket_error_start: Optional[datetime] = None
 
     req: aiohttp.ClientSession
-    headers: Optional[dict] = None
+    headers: Optional[Dict[str, str]] = None
     last_update_id: Optional[UUID] = None
     ws_session: Optional[aiohttp.ClientSession] = None
-    ws_connection: Optional[_WSRequestContextManager] = None
-    ws_task: Optional[asyncio.Task] = None
+    ws_connection: Optional[aiohttp.ClientWebSocketResponse] = None
+    ws_task: Optional[asyncio.Task[None]] = None
     ws_callback: Optional[Callable[[aiohttp.WSMessage], None]] = None
 
     def __init__(
@@ -97,7 +96,7 @@ class BaseApiClient:
         password: str,
         verify_ssl: bool = True,
         session: Optional[aiohttp.ClientSession] = None,
-    ):
+    ) -> None:
         self._host = host
         self._port = port
         self._base_url = f"https://{host}:{port}"
@@ -112,14 +111,16 @@ class BaseApiClient:
         self.req = session
 
     @property
-    def api_path(self):
+    def api_path(self) -> str:
         return "/proxy/protect/api/"
 
     @property
-    def ws_path(self):
+    def ws_path(self) -> str:
         return "/proxy/protect/ws/"
 
-    async def request(self, method, url, require_auth=False, auto_close=True, **kwargs):
+    async def request(
+        self, method: str, url: str, require_auth: bool = False, auto_close: bool = True, **kwargs: Any
+    ) -> aiohttp.ClientResponse:
         """Make a request to Unifi Protect"""
 
         if require_auth:
@@ -158,15 +159,15 @@ class BaseApiClient:
         except client_exceptions.ClientError as err:
             raise NvrError(f"Error requesting data from {self._host}: {err}") from None
 
-    async def api_request(
+    async def api_request_raw(
         self,
-        url,
-        method="get",
-        raw=False,
-        require_auth=True,
-        raise_exception=True,
-        **kwargs,
-    ):
+        url: str,
+        method: str = "get",
+        raw: bool = False,
+        require_auth: bool = True,
+        raise_exception: bool = True,
+        **kwargs: Any,
+    ) -> Optional[bytes]:
         """Make a request to Unifi Protect API"""
 
         if require_auth:
@@ -184,11 +185,7 @@ class BaseApiClient:
                 _LOGGER.warning(msg, url, response.status, reason)
                 return None
 
-            data: Optional[Union[bytes, dict]] = None
-            if raw:
-                data = await response.read()
-            else:
-                data = await response.json()
+            data: Optional[bytes] = await response.read()
             response.release()
 
             return data
@@ -198,12 +195,63 @@ class BaseApiClient:
             # re-raise exception
             raise
 
-    async def ensure_authenticated(self):
+    async def api_request(
+        self,
+        url: str,
+        method: str = "get",
+        require_auth: bool = True,
+        raise_exception: bool = True,
+        **kwargs: Any,
+    ) -> Optional[Union[List[Any], Dict[str, Any]]]:
+        data = await self.api_request_raw(
+            url=url, method=method, require_auth=require_auth, raise_exception=raise_exception, **kwargs
+        )
+
+        if data is not None:
+            json_data: Union[List[Any], Dict[str, Any]] = pjson.loads(data)
+            return json_data
+        return None
+
+    async def api_request_obj(
+        self,
+        url: str,
+        method: str = "get",
+        require_auth: bool = True,
+        raise_exception: bool = True,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        data = await self.api_request(
+            url=url, method=method, require_auth=require_auth, raise_exception=raise_exception, **kwargs
+        )
+
+        if not isinstance(data, dict):
+            raise NvrError(f"Could not decode object from {url}")
+
+        return data
+
+    async def api_request_list(
+        self,
+        url: str,
+        method: str = "get",
+        require_auth: bool = True,
+        raise_exception: bool = True,
+        **kwargs: Any,
+    ) -> List[Any]:
+        data = await self.api_request(
+            url=url, method=method, require_auth=require_auth, raise_exception=raise_exception, **kwargs
+        )
+
+        if not isinstance(data, list):
+            raise NvrError(f"Could not decode list from {url}")
+
+        return data
+
+    async def ensure_authenticated(self) -> None:
         """Ensure we are authenticated."""
         if self.is_authenticated() is False:
             await self.authenticate()
 
-    async def authenticate(self):
+    async def authenticate(self) -> None:
         """Authenticate and get a token."""
 
         url = "/api/auth/login"
@@ -249,7 +297,7 @@ class BaseApiClient:
 
         return self._is_authenticated
 
-    def disconnect_ws(self):
+    def disconnect_ws(self) -> None:
         """Disconnects from the websocket if already connected."""
         if self.ws_connection is not None:
             return
@@ -261,7 +309,7 @@ class BaseApiClient:
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Could not cancel ws_task")
 
-    async def async_connect_ws(self):
+    async def async_connect_ws(self) -> None:
         """Connect the websocket."""
         if self.ws_connection is not None:
             return
@@ -269,15 +317,16 @@ class BaseApiClient:
         self.disconnect_ws()
         self.ws_task = asyncio.ensure_future(self._setup_websocket())
 
-    async def async_disconnect_ws(self):
+    async def async_disconnect_ws(self) -> None:
         """Disconnect the websocket."""
         if self.ws_connection is None:
             return
 
         await self.ws_connection.close()
-        await self.ws_session.close()
+        if self.ws_session is not None:
+            await self.ws_session.close()
 
-    async def _setup_websocket(self):
+    async def _setup_websocket(self) -> None:
         await self.ensure_authenticated()
 
         url = urljoin(f"{self._base_ws_url}{self.ws_path}", "updates")
@@ -311,7 +360,7 @@ class BaseApiClient:
             _LOGGER.debug("websocket disconnected")
             self.ws_connection = None
 
-    def _log_websocket_failure(self):
+    def _log_websocket_failure(self) -> None:
         now = datetime.now()
         if self._websocket_error_start is None:
             self._websocket_error_start = now
@@ -323,7 +372,7 @@ class BaseApiClient:
             log = _LOGGER.debug
         log("Unifi OS: Websocket connection not active, failing back to polling")
 
-    def _process_ws_message(self, msg: aiohttp.WSMessage):
+    def _process_ws_message(self, msg: aiohttp.WSMessage) -> None:
         raise NotImplementedError()
 
 
@@ -334,10 +383,10 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
 
     _event_state_machine: ProtectEventStateMachine = ProtectEventStateMachine()
     _device_state_machine: ProtectDeviceStateMachine = ProtectDeviceStateMachine()
-    _processed_data: Dict[str, dict] = {}
+    _processed_data: Dict[str, Dict[str, Any]] = {}
     _last_websocket_check: float = NEVER_RAN
     _last_device_update_time: float = NEVER_RAN
-    _ws_subscriptions: List[Callable[[Dict[str, dict]], None]] = []
+    _ws_subscriptions: List[Callable[[Dict[str, Dict[str, Any]]], None]] = []
     _is_first_update: bool = True
 
     def __init__(
@@ -349,17 +398,17 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
         password: str,
         verify_ssl: bool = False,
         minimum_score: int = 0,
-    ):
+    ) -> None:
         super().__init__(host, port, username, password, verify_ssl, session=session)
 
         self._minimum_score = minimum_score
 
     @property
-    def devices(self):
+    def devices(self) -> Dict[str, Dict[str, Any]]:
         """Returns a JSON formatted list of Devices."""
         return self._processed_data
 
-    async def update(self, force_camera_update=False) -> dict:
+    async def update(self, force_camera_update: bool = False) -> Dict[str, Any]:
         """Updates the status of devices."""
 
         current_time = time.monotonic()
@@ -392,20 +441,21 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
 
         return self._processed_data if device_update else updates
 
-    async def server_information(self):
+    async def server_information(self) -> Dict[str, Any]:
         """Returns a Server Information for this NVR."""
         return await self._get_server_info()
 
     async def _get_unique_id(self) -> str:
         """Get a Unique ID for this NVR."""
 
-        return (await self._get_server_info())[SERVER_ID]
+        server_id: str = (await self._get_server_info())[SERVER_ID]
+        return server_id
 
-    async def _get_server_info(self) -> dict:
+    async def _get_server_info(self) -> Dict[str, Any]:
         """Get Server Information for this NVR."""
 
-        data = await self.api_request("bootstrap")
-        nvr_data = data["nvr"]
+        data = await self.api_request_obj("bootstrap")
+        nvr_data: Dict[str, Any] = data["nvr"]
 
         return {
             SERVER_NAME: nvr_data["name"],
@@ -415,11 +465,11 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
             "server_ip": nvr_data["host"],
         }
 
-    async def _get_device_list(self, include_events) -> None:
+    async def _get_device_list(self, include_events: bool) -> None:
         """Get a list of devices connected to the NVR."""
 
-        data = await self.api_request("bootstrap")
-        server_id = data["nvr"]["mac"]
+        data = await self.api_request_obj("bootstrap")
+        server_id: str = data["nvr"]["mac"]
         if not self.ws_connection and "lastUpdateId" in data:
             self.last_update_id = UUID(data["lastUpdateId"])
 
@@ -430,7 +480,7 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
 
         self._is_first_update = False
 
-    def _process_cameras_json(self, json_response, server_id, include_events):
+    def _process_cameras_json(self, json_response: Dict[str, Any], server_id: str, include_events: bool) -> None:
         for camera in json_response["cameras"]:
 
             # Ignore cameras adopted by another controller on the same network
@@ -453,7 +503,7 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
                 ),
             )
 
-    def _process_lights_json(self, json_response, server_id, include_events):
+    def _process_lights_json(self, json_response: Dict[str, Any], server_id: str, include_events: bool) -> None:
         for light in json_response["lights"]:
 
             # Ignore lights adopted by another controller on the same network
@@ -472,7 +522,7 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
                 process_light(server_id, light, include_events or self._is_first_update),
             )
 
-    def _process_sensors_json(self, json_response, server_id, include_events):
+    def _process_sensors_json(self, json_response: Dict[str, Any], server_id: str, include_events: bool) -> None:
         for sensor in json_response["sensors"]:
 
             # Ignore lights adopted by another controller on the same network
@@ -491,7 +541,7 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
                 process_sensor(server_id, sensor, include_events or self._is_first_update),
             )
 
-    def _process_viewports_json(self, json_response, server_id, include_events):
+    def _process_viewports_json(self, json_response: Dict[str, Any], server_id: str, include_events: bool) -> None:
         for viewport in json_response["viewers"]:
 
             # Ignore viewports adopted by another controller on the same network
@@ -515,7 +565,7 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
         for device_id in self._processed_data:
             self._update_device(device_id, PROCESSED_EVENT_EMPTY)
 
-    def _process_events(self, events: List[dict], ring_interval: int) -> dict:
+    def _process_events(self, events: List[Dict[str, Any]], ring_interval: int) -> Dict[str, Any]:
         updated = {}
         for event in events:
             if event["type"] not in (EVENT_MOTION, EVENT_RING, EVENT_SMART_DETECT_ZONE):
@@ -530,7 +580,13 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
 
         return updated
 
-    async def _get_events(self, lookback: int = 86400, camera=None, start_time=None, end_time=None) -> dict:
+    async def _get_events(
+        self,
+        lookback: int = 86400,
+        camera: Optional[str] = None,
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """Load the Event Log and loop through items to find motion events."""
 
         now = int(time.time() * 1000)
@@ -548,9 +604,12 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
             params["cameras"] = camera
         data = await self.api_request("events", params=params)
 
+        if not isinstance(data, list):
+            raise NvrError("Could not decode events")
+
         return self._process_events(data, event_ring_check_converted)
 
-    async def get_raw_events(self, lookback: int = 86400) -> dict:
+    async def get_raw_events(self, lookback: int = 86400) -> List[Any]:
         """Load the Event Log and return the Raw Data - Used for debugging only."""
 
         event_start = datetime.now() - timedelta(seconds=lookback)
@@ -562,14 +621,15 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
             "end": str(end_time),
             "start": str(start_time),
         }
-        return await self.api_request("events", params=params)
 
-    async def get_raw_device_info(self) -> dict:
+        return await self.api_request_list("events", params=params)
+
+    async def get_raw_device_info(self) -> Dict[str, Any]:
         """Return the RAW JSON data from this NVR.
         Used for debugging purposes only.
         """
 
-        return await self.api_request("bootstrap")
+        return await self.api_request_obj("bootstrap")
 
     async def get_thumbnail(self, camera_id: str, width: int = 640) -> Optional[bytes]:
         """Returns the last recorded Thumbnail, based on Camera ID."""
@@ -585,7 +645,7 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
             "h": str(height),
             "w": str(width),
         }
-        return await self.api_request(f"thumbnails/{thumbnail_id}", params=params, raw=True)
+        return await self.api_request_raw(f"thumbnails/{thumbnail_id}", params=params)
 
     async def get_heatmap(self, camera_id: str) -> Optional[bytes]:
         """Returns the last recorded Heatmap, based on Camera ID."""
@@ -596,11 +656,11 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
         if heatmap_id is None:
             return None
 
-        return await self.api_request(f"heatmaps/{heatmap_id}", raw=True)
+        return await self.api_request_raw(f"heatmaps/{heatmap_id}")
 
     async def get_snapshot_image(
         self, camera_id: str, width: Optional[int] = None, height: Optional[int] = None
-    ) -> bytes:
+    ) -> Optional[bytes]:
         """Returns a Snapshot image of a recording event."""
 
         time_since = int(time.mktime(datetime.now().timetuple())) * 1000
@@ -614,7 +674,7 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
             "force": "true",
             "w": image_width,
         }
-        return await self.api_request(f"cameras/{camera_id}/snapshot", params=params, raise_exception=False, raw=True)
+        return await self.api_request_raw(f"cameras/{camera_id}/snapshot", params=params, raise_exception=False)
 
     async def get_snapshot_image_direct(self, camera_id: str) -> bytes:
         """Returns a Snapshot image of a recording event.
@@ -660,7 +720,7 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
 
         if device_model == DEVICE_MODEL_LIGHT:
             uri = f"lights/{device_id}"
-            data: Dict[str, dict] = {"lightDeviceSettings": {"isIndicatorEnabled": mode}}
+            data: Dict[str, Dict[str, Any]] = {"lightDeviceSettings": {"isIndicatorEnabled": mode}}
         else:
             uri = f"cameras/{device_id}"
             data = {"ledSettings": {"isEnabled": mode, "blinkRate": 0}}
@@ -755,13 +815,13 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
         self._processed_data[camera_id]["mic_volume"] = level
         return True
 
-    async def set_light_on_off(self, light_id: str, turn_on: bool, led_level=None) -> bool:
+    async def set_light_on_off(self, light_id: str, turn_on: bool, led_level: Optional[int] = None) -> bool:
         """Sets the light on or off.
         turn_on can be: true or false.
         led_level: must be between 1 and 6 or None
         """
 
-        data = {"lightOnSettings": {"isLedForceOn": turn_on}}
+        data: Dict[str, Any] = {"lightOnSettings": {"isLedForceOn": turn_on}}
         if led_level is not None:
             data["lightDeviceSettings"] = {"ledLevel": led_level}
 
@@ -773,7 +833,14 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
             processed_light["brightness"] = led_level
         return True
 
-    async def light_settings(self, light_id: str, mode: str, enable_at=None, duration=None, sensitivity=None) -> bool:
+    async def light_settings(
+        self,
+        light_id: str,
+        mode: str,
+        enable_at: Optional[Literal["dark", "fulltime"]] = None,
+        duration: Optional[int] = None,
+        sensitivity: Optional[int] = None,
+    ) -> bool:
         """Sets PIR settings for a Light Device.
         mode can be: off, motion or always
         enableAt can be: dark, fulltime
@@ -785,9 +852,9 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
         if mode not in LIGHT_MODES:
             mode = "motion"
 
-        data = {"lightModeSettings": {"mode": mode}}
+        data: Dict[str, Any] = {"lightModeSettings": {"mode": mode}}
         if enable_at is not None:
-            setting = data["lightModeSettings"]
+            setting: Dict[str, Any] = data["lightModeSettings"]
             setting["enableAt"] = enable_at
         if duration is not None:
             if data.get("lightDeviceSettings"):
@@ -814,7 +881,9 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
             processed_light["pir_sensitivity"] = sensitivity
         return True
 
-    async def set_privacy_mode(self, camera_id: str, mode: bool, mic_level=-1, recording_mode="notset") -> bool:
+    async def set_privacy_mode(
+        self, camera_id: str, mode: bool, mic_level: int = -1, recording_mode: str = "notset"
+    ) -> bool:
         """Sets the camera privacy mode.
         When True, creates a privacy zone that fills the camera
         When False, removes the Privacy Zone
@@ -856,28 +925,30 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
         self._processed_data[camera_id]["privacy_on"] = mode
         return True
 
-    async def _get_camera_detail(self, camera_id: str) -> dict:
+    async def _get_camera_detail(self, camera_id: str) -> Dict[str, Any]:
         """Return the RAW JSON data for Camera.
         Used for debugging only.
         """
 
-        return await self.api_request(f"cameras/{camera_id}")
+        return await self.api_request_obj(f"cameras/{camera_id}")
 
-    async def _get_viewport_detail(self, viewport_id: str) -> dict:
+    async def _get_viewport_detail(self, viewport_id: str) -> Dict[str, Any]:
         """Return the RAW JSON data for a Viewport.
         Used for debugging only.
         """
 
-        return await self.api_request(f"viewers/{viewport_id}")
+        return await self.api_request_obj(f"viewers/{viewport_id}")
 
-    async def _get_light_detail(self, light_id: str) -> dict:
+    async def _get_light_detail(self, light_id: str) -> Dict[str, Any]:
         """Return the RAW JSON data for a Light.
         Used for debugging only.
         """
 
-        return await self.api_request(f"lights/{light_id}")
+        return await self.api_request_obj(f"lights/{light_id}")
 
-    async def set_doorbell_lcd_text(self, camera_id: str, text_type: str, text_display: str, duration=None) -> bool:
+    async def set_doorbell_lcd_text(
+        self, camera_id: str, text_type: str, text_display: str, duration: Optional[int] = None
+    ) -> bool:
         """Sets a Text string for the Doorbell LCD'."""
 
         # Truncate text to max 30 characters, as this is what is supported
@@ -907,17 +978,19 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
 
         data = {"liveview": view_id}
         await self.api_request(f"viewers/{viewport_id}", method="patch", json=data)
+
         self._device_state_machine.update(viewport_id, data)
         processed_viewport = self._processed_data[viewport_id]
         processed_viewport["liveview"] = view_id
         return True
 
-    async def get_live_views(self) -> List[Dict[str, dict]]:
+    async def get_live_views(self) -> List[Dict[str, Dict[str, Any]]]:
         """Returns a list of all defined Live Views."""
 
-        data = await self.api_request("liveviews")
+        liveviews = await self.api_request_list("liveviews")
+
         views = []
-        for view in data:
+        for view in liveviews:
             item = {
                 "name": view.get("name"),
                 "id": view.get("id"),
@@ -925,20 +998,20 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
             views.append(item)
         return views
 
-    def subscribe_websocket(self, ws_callback):
+    def subscribe_websocket(self, ws_callback: Callable[[Dict[str, Dict[str, Any]]], None]) -> Callable[[], None]:
         """Subscribe to websocket events.
 
         Returns a callback that will unsubscribe.
         """
 
-        def _unsub_ws_callback():
+        def _unsub_ws_callback() -> None:
             self._ws_subscriptions.remove(ws_callback)
 
         _LOGGER.debug("Adding subscription: %s", ws_callback)
         self._ws_subscriptions.append(ws_callback)
         return _unsub_ws_callback
 
-    def _process_ws_message(self, msg: aiohttp.WSMessage):
+    def _process_ws_message(self, msg: aiohttp.WSMessage) -> None:
         """Process websocket messages."""
         action_frame, action_frame_payload_format, position = decode_ws_frame(msg.data, 0)
 
@@ -982,13 +1055,13 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
 
         raise ValueError(f"Unexpected model key: {model_key}")
 
-    def _process_camera_ws_message(self, action_json, data_json):
+    def _process_camera_ws_message(self, action_json: Dict[str, Any], data_json: Dict[str, Any]) -> None:
         """Process a decoded camera websocket message."""
         camera_id, processed_camera = camera_update_from_ws_frames(
             self._device_state_machine, self._host, action_json, data_json
         )
 
-        if camera_id is None:
+        if camera_id is None or processed_camera is None:
             return
         _LOGGER.debug("Processed camera: %s", processed_camera)
 
@@ -1000,11 +1073,11 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
 
         self.fire_event(camera_id, processed_camera)
 
-    def _process_light_ws_message(self, action_json, data_json):
+    def _process_light_ws_message(self, action_json: Dict[str, Any], data_json: Dict[str, Any]) -> None:
         """Process a decoded light websocket message."""
         light_id, processed_light = light_update_from_ws_frames(self._device_state_machine, action_json, data_json)
 
-        if light_id is None:
+        if light_id is None or processed_light is None:
             return
         _LOGGER.debug("Processed light: %s %s", processed_light["motion_mode"], processed_light)
 
@@ -1016,11 +1089,11 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
 
         self.fire_event(light_id, processed_light)
 
-    def _process_sensor_ws_message(self, action_json, data_json):
+    def _process_sensor_ws_message(self, action_json: Dict[str, Any], data_json: Dict[str, Any]) -> None:
         """Process a decoded sensor websocket message."""
         sensor_id, processed_sensor = sensor_update_from_ws_frames(self._device_state_machine, action_json, data_json)
 
-        if sensor_id is None:
+        if sensor_id is None or processed_sensor is None:
             return
         _LOGGER.debug(
             "Processed sensor: %s %s",
@@ -1036,13 +1109,13 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
 
         self.fire_event(sensor_id, processed_sensor)
 
-    def _process_event_ws_message(self, action_json, data_json):
+    def _process_event_ws_message(self, action_json: Dict[str, Any], data_json: Dict[str, Any]) -> None:
         """Process a decoded event websocket message."""
         device_id, processed_event = event_from_ws_frames(
             self._event_state_machine, self._minimum_score, action_json, data_json
         )
 
-        if device_id is None:
+        if device_id is None or processed_event is None:
             return
 
         _LOGGER.debug("Procesed event: %s", processed_event)
@@ -1056,14 +1129,14 @@ class UpvServer(BaseApiClient):  # pylint: disable=too-many-public-methods, too-
             processed_event["event_ring_on"] = False
             self.fire_event(device_id, processed_event)
 
-    def fire_event(self, device_id, processed_event):
+    def fire_event(self, device_id: str, processed_event: Dict[str, Any]) -> None:
         """Callback and event to the subscribers and update data."""
         self._update_device(device_id, processed_event)
 
         for subscriber in self._ws_subscriptions:
             subscriber({device_id: self._processed_data[device_id]})
 
-    def _update_device(self, device_id, processed_update):
+    def _update_device(self, device_id: str, processed_update: Dict[str, Any]) -> None:
         """Update internal state of a device."""
         self._processed_data.setdefault(device_id, {}).update(processed_update)
 
@@ -1077,12 +1150,12 @@ class ProtectApiClient(BaseApiClient):
     _last_websocket_check: Optional[datetime] = None
     _websocket_failures: int = 0
 
-    def __init__(self, *args, minimum_score: int = 0, **kwargs):
+    def __init__(self, *args: Any, minimum_score: int = 0, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
         self._minimum_score = minimum_score
 
-    async def update(self, force=False) -> Union[Bootstrap, List[Event]]:
+    async def update(self, force: bool = False) -> Union[Bootstrap, List[Event]]:
         now = datetime.now()
 
         if force and self.ws_connection is not None:
@@ -1096,7 +1169,7 @@ class ProtectApiClient(BaseApiClient):
             or now - self._last_update > DEVICE_UPDATE_INTERVAL
         ):
             self._last_update = now
-            data = await self.api_request("bootstrap")
+            data = await self.api_request_obj("bootstrap")
             self._bootstrap = Bootstrap(**data, api=self)
 
         if self._last_websocket_check is None or now - self._last_websocket_check > WEBSOCKET_CHECK_INTERVAL:
@@ -1118,7 +1191,7 @@ class ProtectApiClient(BaseApiClient):
         self._last_update = now
         return events
 
-    def _process_ws_message(self, msg: aiohttp.WSMessage):
+    def _process_ws_message(self, msg: aiohttp.WSMessage) -> None:
         packet = WSPacket(msg.data)
         self.bootstrap.process_ws_packet(packet)
 
@@ -1170,7 +1243,7 @@ class ProtectApiClient(BaseApiClient):
         if camera_ids is not None:
             params["cameras"] = ",".join(camera_ids)
 
-        return await self.api_request("events", params=params)
+        return await self.api_request_list("events", params=params)
 
     async def get_events(
         self,

--- a/pyunifiprotect/unifi_protect_server.py
+++ b/pyunifiprotect/unifi_protect_server.py
@@ -170,7 +170,6 @@ class BaseApiClient:
         self,
         url: str,
         method: str = "get",
-        raw: bool = False,
         require_auth: bool = True,
         raise_exception: bool = True,
         **kwargs: Any,

--- a/pyunifiprotect/unifi_protect_server.py
+++ b/pyunifiprotect/unifi_protect_server.py
@@ -71,7 +71,7 @@ _LOGGER = logging.getLogger(__name__)
 
 # TODO: Remove when 3.8 support is dropped
 if TYPE_CHECKING:
-    TaskClass = asyncio.Task[None]  # pylint: disable=unsubscriptable-object
+    TaskClass = asyncio.Task[None]
 else:
     TaskClass = asyncio.Task
 

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -72,7 +72,7 @@ def format_datetime(dt: Optional[datetime], default: Optional[str] = None) -> Op
 
 def is_online(data: Dict[str, Any]) -> bool:
 
-    return data["state"] == "CONNECTED"
+    return bool(data["state"] == "CONNECTED")
 
 
 def is_doorbell(data: Dict[str, Any]) -> bool:
@@ -120,7 +120,7 @@ def serialize_unifi_obj(value: Any) -> Any:
     return value
 
 
-def serialize_dict(data: Dict[str, Any]):
+def serialize_dict(data: Dict[str, Any]) -> Dict[str, Any]:
     for key in list(data.keys()):
         data[to_camel_case(key)] = serialize_unifi_obj(data.pop(key))
 

--- a/tests/sample_data/constants.py
+++ b/tests/sample_data/constants.py
@@ -1,7 +1,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 UFP_SAMPLE_DIR = os.environ.get("UFP_SAMPLE_DIR")
 if UFP_SAMPLE_DIR:
@@ -11,7 +11,7 @@ else:
 
 
 class ConstantData:
-    _data: Optional[dict] = None
+    _data: Optional[Dict[str, Any]] = None
 
     def __getitem__(self, key):
         return self.data().__getitem__(key)

--- a/tests/test_unifi_protect_server.py
+++ b/tests/test_unifi_protect_server.py
@@ -63,7 +63,10 @@ async def test_get_events_raw_default(protect_client: ProtectApiClient, now: dat
     end = now + timedelta(seconds=10)
 
     protect_client.api_request.assert_called_with(  # type: ignore
-        "events",
+        url="events",
+        method="get",
+        require_auth=True,
+        raise_exception=True,
         params={
             "start": to_js_time(end - timedelta(hours=24)),
             "end": to_js_time(end),
@@ -80,7 +83,10 @@ async def test_get_events_raw_limit(protect_client: ProtectApiClient):
     await protect_client.get_events_raw(limit=10)
 
     protect_client.api_request.assert_called_with(  # type: ignore
-        "events",
+        url="events",
+        method="get",
+        require_auth=True,
+        raise_exception=True,
         params={"limit": 10},
     )
 
@@ -90,7 +96,10 @@ async def test_get_events_raw_cameras(protect_client: ProtectApiClient):
     await protect_client.get_events_raw(limit=10, camera_ids=["test1", "test2"])
 
     protect_client.api_request.assert_called_with(  # type: ignore
-        "events",
+        url="events",
+        method="get",
+        require_auth=True,
+        raise_exception=True,
         params={"limit": 10, "cameras": "test1,test2"},
     )
 

--- a/tests/test_unifi_protect_server_ws.py
+++ b/tests/test_unifi_protect_server_ws.py
@@ -6,7 +6,7 @@ import asyncio
 import base64
 from copy import deepcopy
 from datetime import timedelta
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -27,7 +27,7 @@ def packet():
 
 
 @pytest.mark.asyncio
-async def test_ws_all(protect_client_ws: ProtectApiClient, ws_messages: Dict[str, dict]):
+async def test_ws_all(protect_client_ws: ProtectApiClient, ws_messages: Dict[str, Dict[str, Any]]):
     # wait for ws connection
     for _ in range(60):
         if protect_client_ws.ws_connection is not None:


### PR DESCRIPTION
Last dozy of a PR, I swear. 

Enables a lot more strict typing flags for mypy and adds the needed type hints everywhere.

The major changes outside of type hints:

* Adds defaults to various places we use `.get` on a dict
* Removes `raw` from `api_request` and splits that one call into four to help with typing: `api_request_raw` (returns `bytes`), `api_request` (returns `dict` | `list`), `api_request_obj` (returns `dict`) and `api_request_list` (returns `list`)

I can move these changes into smaller PRs, but for this, it might be better to just test everything all at once.

## HA Install Link:

```
git+https://github.com/AngellusMortis/pyunifiprotect.git@feature/strict-mypy#pyunifiprotect==0.35.3
```