### PR TITLE
Makes nested Protect Objects smarter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,9 @@ good-names = [
 # inconsistent-return-statements - doesn't handle raise
 # too-many-ancestors - it's too strict.
 # wrong-import-order - isort guards this
-# no-member - mypy handles this better
-# unsupported-membership-test - mypy handles this better
-# unsubscriptable-object - mypy handles this better
+
+# handled by mypy:
+# no-member, unsupported-membership-test, unsupported-assignment-operation, unsubscriptable-object
 disable = [
     "format",
     "abstract-class-little-used",
@@ -118,7 +118,11 @@ disable = [
     "fixme",
     "no-member",
     "unsupported-membership-test",
+<<<<<<< HEAD
     "unsubscriptable-object",
+=======
+    "unsupported-assignment-operation",
+>>>>>>> fba4dc3 (Makes nested Protect Objects smarter)
 ]
 enable = [
     #"useless-suppression",  # temporarily every now and then to clean them up

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,11 +118,8 @@ disable = [
     "fixme",
     "no-member",
     "unsupported-membership-test",
-<<<<<<< HEAD
     "unsubscriptable-object",
-=======
     "unsupported-assignment-operation",
->>>>>>> fba4dc3 (Makes nested Protect Objects smarter)
 ]
 enable = [
     #"useless-suppression",  # temporarily every now and then to clean them up

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -87,7 +87,7 @@ class ProtectBaseObject(BaseModel):
         return {}
 
     @classmethod
-    def _set_project_subtypes(cls) -> None:
+    def _set_protect_subtypes(cls) -> None:
         """Helper method to detect attrs of current class that are UFP Objects themselves"""
 
         cls._protect_objs = {}
@@ -112,7 +112,7 @@ class ProtectBaseObject(BaseModel):
         if cls._protect_objs is not None:
             return cls._protect_objs  # type: ignore
 
-        cls._set_project_subtypes()
+        cls._set_protect_subtypes()
         return cls._protect_objs  # type: ignore
 
     @classmethod
@@ -121,7 +121,7 @@ class ProtectBaseObject(BaseModel):
         if cls._protect_lists is not None:
             return cls._protect_lists  # type: ignore
 
-        cls._set_project_subtypes()
+        cls._set_protect_subtypes()
         return cls._protect_lists  # type: ignore
 
     @classmethod
@@ -130,7 +130,7 @@ class ProtectBaseObject(BaseModel):
         if cls._protect_dicts is not None:
             return cls._protect_dicts  # type: ignore
 
-        cls._set_project_subtypes()
+        cls._set_protect_subtypes()
         return cls._protect_dicts  # type: ignore
 
     @classmethod
@@ -144,7 +144,7 @@ class ProtectBaseObject(BaseModel):
         return api
 
     @classmethod
-    def _clean_project_obj(cls, data: Any, klass: Type[ProtectBaseObject], api: Optional[ProtectApiClient]) -> Any:
+    def _clean_protect_obj(cls, data: Any, klass: Type[ProtectBaseObject], api: Optional[ProtectApiClient]) -> Any:
         if isinstance(data, dict):
             if api is not None:
                 data["api"] = api
@@ -152,21 +152,21 @@ class ProtectBaseObject(BaseModel):
         return data
 
     @classmethod
-    def _clean_project_obj_list(
+    def _clean_protect_obj_list(
         cls, items: List[Any], klass: Type[ProtectBaseObject], api: Optional[ProtectApiClient]
     ) -> List[Any]:
         cleaned_items: List[Any] = []
         for item in items:
-            cleaned_items.append(cls._clean_project_obj(item, klass, api))
+            cleaned_items.append(cls._clean_protect_obj(item, klass, api))
         return cleaned_items
 
     @classmethod
-    def _clean_project_obj_dict(
+    def _clean_protect_obj_dict(
         cls, items: Dict[Any, Any], klass: Type[ProtectBaseObject], api: Optional[ProtectApiClient]
     ) -> Dict[Any, Any]:
         cleaned_items: Dict[Any, Any] = {}
         for key, value in items.items():
-            cleaned_items[key] = cls._clean_project_obj(value, klass, api)
+            cleaned_items[key] = cls._clean_protect_obj(value, klass, api)
         return cleaned_items
 
     @classmethod
@@ -192,15 +192,15 @@ class ProtectBaseObject(BaseModel):
         api = cls._get_api(data)
         for key, klass in cls._get_protect_objs().items():
             if key in data:
-                data[key] = cls._clean_project_obj(data[key], klass, api)
+                data[key] = cls._clean_protect_obj(data[key], klass, api)
 
         for key, klass in cls._get_protect_lists().items():
             if key in data and isinstance(data[key], list):
-                data[key] = cls._clean_project_obj_list(data[key], klass, api)
+                data[key] = cls._clean_protect_obj_list(data[key], klass, api)
 
         for key, klass in cls._get_protect_dicts().items():
             if key in data and isinstance(data[key], dict):
-                data[key] = cls._clean_project_obj_dict(data[key], klass, api)
+                data[key] = cls._clean_protect_obj_dict(data[key], klass, api)
 
         return data
 

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -36,7 +36,7 @@ class ProtectBaseObject(BaseModel):
     """
     Base class for building Python objects from Unifi Protect JSON.
 
-    * Provides `.clean_unifi_dict` to convert UFP JSON to a more Pythonic formatted dict (camel case to snake case)
+    * Provides `.unifi_dict_to_dict` to convert UFP JSON to a more Pythonic formatted dict (camel case to snake case)
     * Add attrs with matching Pyhonic name and they will automatically be populated from the UFP JSON if passed in to the constructer
     * Provides `.unifi_dict` to convert object back into UFP JSON
     """
@@ -65,7 +65,7 @@ class ProtectBaseObject(BaseModel):
         (cameras, users, etc.)
         """
         data["api"] = api
-        data = self.clean_unifi_dict(data)
+        data = self.unifi_dict_to_dict(data)
         del data["api"]
         super().__init__(**data)
 
@@ -147,7 +147,7 @@ class ProtectBaseObject(BaseModel):
         if isinstance(data, dict):
             if api is not None:
                 data["api"] = api
-            return klass.clean_unifi_dict(data=data)
+            return klass.unifi_dict_to_dict(data=data)
         return data
 
     @classmethod
@@ -169,14 +169,14 @@ class ProtectBaseObject(BaseModel):
         return cleaned_items
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Takes a decoded UFP JSON dict and converts it into a Python dict
 
         * Remaps items from `._get_unifi_remaps()`
         * Converts camelCase keys to snake_case keys
         * Injects ProtectAPIClient into any child UFP object Dicts
-        * Runs `.clean_unifi_dict` for any child UFP objects
+        * Runs `.unifi_dict_to_dict` for any child UFP objects
 
         :param data: decoded UFP JSON dict
         """
@@ -304,7 +304,7 @@ class ProtectBaseObject(BaseModel):
 
     def update_from_unifi_dict(self: T, data: Dict[str, Any]) -> T:
         """Updates current object from an uncleaned UFP JSON dict"""
-        data = self.clean_unifi_dict(data)
+        data = self.unifi_dict_to_dict(data)
         return self.update_from_dict(data)
 
     @property
@@ -431,7 +431,7 @@ class ProtectDeviceModel(ProtectModelWithId):
     is_ssh_enabled: bool
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "lastSeen" in data:
             data["lastSeen"] = process_datetime(data, "lastSeen")
         if "upSince" in data and data["upSince"] is not None:
@@ -439,7 +439,7 @@ class ProtectDeviceModel(ProtectModelWithId):
         if "uptime" in data and data["uptime"] is not None and not isinstance(data["uptime"], timedelta):
             data["uptime"] = timedelta(milliseconds=int(data["uptime"]))
 
-        return super().clean_unifi_dict(data)
+        return super().unifi_dict_to_dict(data)
 
 
 class WiredConnectionState(ProtectBaseObject):

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -6,7 +6,6 @@ from ipaddress import IPv4Address
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     ClassVar,
     Dict,
     List,
@@ -45,9 +44,9 @@ class ProtectBaseObject(BaseModel):
     _api: Optional[ProtectApiClient] = PrivateAttr(None)
     _initial_data: Dict[str, Any] = PrivateAttr()
 
-    _protect_objs: ClassVar[Optional[Dict[str, Callable]]] = None
-    _protect_lists: ClassVar[Optional[Dict[str, Callable]]] = None
-    _protect_dicts: ClassVar[Optional[Dict[str, Callable]]] = None
+    _protect_objs: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
+    _protect_lists: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
+    _protect_dicts: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
     _unifi_remaps: ClassVar[Optional[Dict[str, str]]] = None
 
     class Config:
@@ -110,7 +109,7 @@ class ProtectBaseObject(BaseModel):
     def _get_protect_objs(cls) -> Dict[str, Type[ProtectBaseObject]]:
         """Helper method to get all child UFP objects"""
         if cls._protect_objs is not None:
-            return cls._protect_objs  # type: ignore
+            return cls._protect_objs
 
         cls._set_protect_subtypes()
         return cls._protect_objs  # type: ignore
@@ -119,7 +118,7 @@ class ProtectBaseObject(BaseModel):
     def _get_protect_lists(cls) -> Dict[str, Type[ProtectBaseObject]]:
         """Helper method to get all child of UFP objects (lists)"""
         if cls._protect_lists is not None:
-            return cls._protect_lists  # type: ignore
+            return cls._protect_lists
 
         cls._set_protect_subtypes()
         return cls._protect_lists  # type: ignore
@@ -128,7 +127,7 @@ class ProtectBaseObject(BaseModel):
     def _get_protect_dicts(cls) -> Dict[str, Type[ProtectBaseObject]]:
         """Helper method to get all child of UFP objects (dicts)"""
         if cls._protect_dicts is not None:
-            return cls._protect_dicts  # type: ignore
+            return cls._protect_dicts
 
         cls._set_protect_subtypes()
         return cls._protect_dicts  # type: ignore

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -190,10 +190,10 @@ class ProtectBaseObject(BaseModel):
             return value
 
         items: Dict[Any, Any] = {}
-        for key, obj in value.items():
+        for obj_key, obj in value.items():
             if isinstance(obj, ProtectBaseObject):
                 obj = obj.unifi_dict()
-            items[key] = obj
+            items[obj_key] = obj
 
         return items
 

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -9,12 +9,12 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    List,
     Optional,
     Set,
     Type,
     TypeVar,
     Union,
-    List,
 )
 
 from pydantic import BaseModel

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -10,13 +10,14 @@ from typing import (
     ClassVar,
     Dict,
     Optional,
+    Set,
     Type,
     TypeVar,
     Union,
 )
 
 from pydantic import BaseModel
-from pydantic.fields import PrivateAttr
+from pydantic.fields import SHAPE_DICT, SHAPE_LIST, PrivateAttr
 
 from pyunifiprotect.data.types import ModelType, StateType
 from pyunifiprotect.exceptions import BadRequest, DataDecodeError
@@ -35,8 +36,11 @@ class ProtectBaseObject(BaseModel):
     _api: Optional[ProtectApiClient] = PrivateAttr(None)
     _initial_data: Dict[str, Any] = PrivateAttr()
 
+    _protect_objs: ClassVar[Optional[Dict[str, Callable]]] = None
+    _protect_lists: ClassVar[Optional[Dict[str, Callable]]] = None
+    _protect_dicts: ClassVar[Optional[Dict[str, Callable]]] = None
+
     UNIFI_REMAP: ClassVar[Dict[str, str]] = {}
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {}  # type: ignore
 
     class Config:
         arbitrary_types_allowed = True
@@ -44,15 +48,58 @@ class ProtectBaseObject(BaseModel):
     def __init__(self, api: Optional[ProtectApiClient] = None, **data: Any) -> None:
         data["api"] = api
         data = self.clean_unifi_dict(data)
+        del data["api"]
         super().__init__(**data)
 
         self._api = api
 
     @classmethod
+    def _set_project_subtypes(cls) -> None:
+        cls._protect_objs = {}
+        cls._protect_lists = {}
+        cls._protect_dicts = {}
+
+        for name, field in cls.__fields__.items():
+            try:
+                if issubclass(field.type_, ProtectBaseObject):
+                    if field.shape == SHAPE_LIST:
+                        cls._protect_lists[name] = field.type_
+                    if field.shape == SHAPE_DICT:
+                        cls._protect_dicts[name] = field.type_
+                    else:
+                        cls._protect_objs[name] = field.type_
+            except TypeError:
+                pass
+
+    @classmethod
+    def _get_protect_objs(cls) -> Dict[str, Type[ProtectBaseObject]]:
+        if cls._protect_objs is not None:
+            return cls._protect_objs  # type: ignore
+
+        cls._set_project_subtypes()
+        return cls._protect_objs  # type: ignore
+
+    @classmethod
+    def _get_protect_lists(cls) -> Dict[str, Type[ProtectBaseObject]]:
+        if cls._protect_lists is not None:
+            return cls._protect_lists  # type: ignore
+
+        cls._set_project_subtypes()
+        return cls._protect_lists  # type: ignore
+
+    @classmethod
+    def _get_protect_dicts(cls) -> Dict[str, Type[ProtectBaseObject]]:
+        if cls._protect_dicts is not None:
+            return cls._protect_dicts  # type: ignore
+
+        cls._set_project_subtypes()
+        return cls._protect_dicts  # type: ignore
+
+    @classmethod
     def _get_api(cls, data: Dict[str, Any]) -> Optional[ProtectApiClient]:
         api = data.get("api")
 
-        if api is None and hasattr(cls, "_api"):
+        if api is None and isinstance(cls, ProtectBaseObject) and hasattr(cls, "_api"):
             api = cls._api
 
         return api
@@ -63,32 +110,99 @@ class ProtectBaseObject(BaseModel):
             if from_key in data:
                 data[to_key] = data.pop(from_key)
 
-        for key, klass in cls.PROTECT_OBJ_FIELDS.items():
-            if key in data and isinstance(data[key], dict):
-                obj_dict = data[key]
-                obj_dict["api"] = cls._get_api(data)
-                data[key] = klass.clean_unifi_dict(data=obj_dict)  # type: ignore
-
         for key in list(data.keys()):
             data[to_snake_case(key)] = data.pop(key)
 
+        for key, klass in cls._get_protect_objs().items():
+            if key in data and isinstance(data[key], dict):
+                obj_dict = data[key]
+                api = cls._get_api(data)
+                if api is not None:
+                    obj_dict["api"] = api
+                data[key] = klass.clean_unifi_dict(data=obj_dict)
+
+        for key, klass in cls._get_protect_lists().items():
+            if key in data and isinstance(data[key], list):
+                obj_list = data[key]
+                api = cls._get_api(data)
+                cleaned_items = []
+                for obj in obj_list:
+                    if api is not None:
+                        obj["api"] = api
+                    cleaned_items.append(klass.clean_unifi_dict(data=obj))
+                data[key] = cleaned_items
+
+        for key, klass in cls._get_protect_dicts().items():
+            if key in data and isinstance(data[key], dict):
+                obj_dict = data[key]
+                api = cls._get_api(data)
+                cleaned_dict = {}
+                for obj_key, value in obj_dict.items():
+                    if api is not None:
+                        value["api"] = api
+                    cleaned_dict[obj_key] = klass.clean_unifi_dict(data=value)
+                data[key] = cleaned_dict
+
         return data
 
-    def unifi_dict(self, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
+        use_obj = False
         if data is None:
-            data = self.dict()
+            excluded_fields = set(self._get_protect_objs().keys()) | set(self._get_protect_lists().keys())
+            if exclude is not None:
+                excluded_fields = excluded_fields | exclude
+            data = self.dict(exclude=excluded_fields)
+            use_obj = True
 
-        for key in self.PROTECT_OBJ_FIELDS:
-            key = to_snake_case(key)
-            key = self.UNIFI_REMAP.get(key, key)
+        for key in self._get_protect_objs().keys():
+            unifi_obj: Optional[Any] = None
+            if use_obj:
+                unifi_obj = getattr(self, key)
+            elif key in data:
+                unifi_obj = data[key]
 
-            if key in data:
-                unifi_obj: Optional[Any] = getattr(self, key)
-                if unifi_obj is not None and isinstance(unifi_obj, ProtectBaseObject):
-                    data[key] = unifi_obj.unifi_dict(data=data[key])
+            if isinstance(unifi_obj, ProtectBaseObject):
+                data[key] = unifi_obj.unifi_dict()
+            elif use_obj or key in data:
+                data[key] = unifi_obj
+
+        for key in self._get_protect_lists().keys():
+            unifi_list: Optional[Any] = None
+            if use_obj:
+                unifi_list = getattr(self, key)
+            elif key in data:
+                unifi_list = data[key]
+
+            if isinstance(unifi_list, list):
+                objs = []
+                for obj in unifi_list:
+                    if isinstance(obj, ProtectBaseObject):
+                        objs.append(obj.unifi_dict())
+                    else:
+                        objs.append(obj)
+                data[key] = objs
+            elif key in data:
+                data[key] = unifi_list
+
+        for key in self._get_protect_dicts().keys():
+            unifi_dict: Optional[Any] = None
+            if use_obj:
+                unifi_dict = getattr(self, key)
+            elif key in data:
+                unifi_dict = data[key]
+
+            if isinstance(unifi_dict, dict):
+                obj_dict = {}
+                for obj_key, value in unifi_dict.items():
+                    if isinstance(value, ProtectBaseObject):
+                        obj_dict[obj_key] = value.unifi_dict()
+                    else:
+                        obj_dict[obj_key] = value
+                data[key] = obj_dict
+            elif key in data:
+                data[key] = unifi_dict
 
         data: Dict[str, Any] = serialize_unifi_obj(data)
-
         for to_key, from_key in self.UNIFI_REMAP.items():
             if from_key in data:
                 data[to_key] = data.pop(from_key)
@@ -99,10 +213,7 @@ class ProtectBaseObject(BaseModel):
         return data
 
     def update_from_dict(self: T, data: Dict[str, Any]) -> T:
-        for key in self.PROTECT_OBJ_FIELDS:
-            key = to_snake_case(key)
-            key = self.UNIFI_REMAP.get(key, key)
-
+        for key in self._get_protect_objs().keys():
             if key in data:
                 unifi_obj: Optional[Any] = getattr(self, key)
                 if unifi_obj is not None and isinstance(unifi_obj, ProtectBaseObject):
@@ -198,8 +309,8 @@ class ProtectModel(ProtectBaseObject):
 
         return klass(**data, api=api)
 
-    def unifi_dict(self, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        data = super().unifi_dict(data=data)
+    def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
+        data = super().unifi_dict(data=data, exclude=exclude)
 
         if "modelKey" in data and data["modelKey"] is None:
             del data["modelKey"]
@@ -277,8 +388,8 @@ class ProtectAdoptableDeviceModel(ProtectDeviceModel):
 
     UNIFI_REMAP: ClassVar[Dict[str, str]] = {**ProtectDeviceModel.UNIFI_REMAP, **{"bridge": "bridgeId"}}
 
-    def unifi_dict(self, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        data = super().unifi_dict(data=data)
+    def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
+        data = super().unifi_dict(data=data, exclude=exclude)
 
         if "wiredConnectionState" in data and data["wiredConnectionState"] is None:
             del data["wiredConnectionState"]
@@ -318,8 +429,8 @@ class ProtectMotionDeviceModel(ProtectAdoptableDeviceModel):
     # not directly from Unifi
     last_motion_event_id: Optional[str] = None
 
-    def unifi_dict(self, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        data = super().unifi_dict(data=data)
+    def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
+        data = super().unifi_dict(data=data, exclude=exclude)
 
         if "lastMotionEventId" in data:
             del data["lastMotionEventId"]

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -41,11 +41,11 @@ class LightDeviceSettings(ProtectBaseObject):
     pir_sensitivity: PercentInt
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "pirDuration" in data and not isinstance(data["pirDuration"], timedelta):
             data["pirDuration"] = timedelta(milliseconds=data["pirDuration"])
 
-        return super().clean_unifi_dict(data)
+        return super().unifi_dict_to_dict(data)
 
 
 class LightOnSettings(ProtectBaseObject):
@@ -194,7 +194,7 @@ class RecordingSettings(ProtectBaseObject):
     use_new_motion_algorithm: bool
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "prePaddingSecs" in data:
             data["prePadding"] = timedelta(seconds=data.pop("prePaddingSecs"))
         if "postPaddingSecs" in data:
@@ -204,7 +204,7 @@ class RecordingSettings(ProtectBaseObject):
         if "endMotionEventDelay" in data and not isinstance(data["endMotionEventDelay"], timedelta):
             data["endMotionEventDelay"] = timedelta(seconds=data["endMotionEventDelay"])
 
-        return super().clean_unifi_dict(data)
+        return super().unifi_dict_to_dict(data)
 
     def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)
@@ -238,13 +238,13 @@ class LCDMessage(ProtectBaseObject):
     reset_at: Optional[datetime] = None
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "resetAt" in data:
             data["resetAt"] = process_datetime(data, "resetAt")
         if "text" in data:
             data["text"] = cls._fix_text(data["text"], data.get("type"))
 
-        return super().clean_unifi_dict(data)
+        return super().unifi_dict_to_dict(data)
 
     @classmethod
     def _fix_text(cls, text: str, text_type: Optional[str]) -> str:
@@ -315,7 +315,7 @@ class VideoStats(ProtectBaseObject):
         }
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "recordingStart" in data:
             data["recordingStart"] = process_datetime(data, "recordingStart")
         if "recordingEnd" in data:
@@ -333,7 +333,7 @@ class VideoStats(ProtectBaseObject):
         if "timelapseEndLQ" in data:
             data["timelapseEndLQ"] = process_datetime(data, "timelapseEndLQ")
 
-        return super().clean_unifi_dict(data)
+        return super().unifi_dict_to_dict(data)
 
 
 class StorageStats(ProtectBaseObject):
@@ -352,11 +352,11 @@ class CameraStats(ProtectBaseObject):
     wifi_strength: int
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "storage" in data and data["storage"] == {}:
             del data["storage"]
 
-        return super().clean_unifi_dict(data)
+        return super().unifi_dict_to_dict(data)
 
     def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)
@@ -498,12 +498,12 @@ class Camera(ProtectMotionDeviceModel):
     last_smart_detect_event_id: Optional[str] = None
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         # LCD messages comes back as empty dict {}
         if "lcdMessage" in data and len(data["lcdMessage"].keys()) == 0:
             del data["lcdMessage"]
 
-        return super().clean_unifi_dict(data)
+        return super().unifi_dict_to_dict(data)
 
     def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 from uuid import UUID
 
 from pydantic.color import Color
@@ -69,7 +69,9 @@ class Light(ProtectMotionDeviceModel):
     camera_id: Optional[str]
     is_camera_paired: bool
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {**ProtectMotionDeviceModel.UNIFI_REMAP, **{"camera": "cameraId"}}
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "camera": "cameraId"}
 
     @property
     def camera(self) -> Optional[Camera]:
@@ -302,12 +304,15 @@ class VideoStats(ProtectBaseObject):
     timelapse_start_lq: Optional[datetime]
     timelapse_end_lq: Optional[datetime]
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {
-        "recordingStartLQ": "recordingStartLq",
-        "recordingEndLQ": "recordingEndLq",
-        "timelapseStartLQ": "timelapseStartLq",
-        "timelapseEndLQ": "timelapseEndLq",
-    }
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {
+            **super()._get_unifi_remaps(),
+            "recordingStartLQ": "recordingStartLq",
+            "recordingEndLQ": "recordingEndLq",
+            "timelapseStartLQ": "timelapseStartLq",
+            "timelapseEndLQ": "timelapseEndLq",
+        }
 
     @classmethod
     def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -432,7 +437,9 @@ class FeatureFlags(ProtectBaseObject):
     # tilt
     # zoom
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {"hasAutoICROnly": "hasAutoIcrOnly"}
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "hasAutoICROnly": "hasAutoIcrOnly"}
 
 
 class Camera(ProtectMotionDeviceModel):
@@ -532,7 +539,9 @@ class Viewer(ProtectAdoptableDeviceModel):
     software_version: str
     liveview_id: str
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {**ProtectAdoptableDeviceModel.UNIFI_REMAP, **{"liveview": "liveviewId"}}
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "liveview": "liveviewId"}
 
     @property
     def liveview(self) -> Liveview:
@@ -575,12 +584,6 @@ class SensorStats(ProtectBaseObject):
     humidity: SensorStat
     temperature: SensorStat
 
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
-        "light": SensorStat,
-        "humidity": SensorStat,
-        "temperature": SensorStat,
-    }
-
 
 class Sensor(ProtectAdoptableDeviceModel):
     alarm_settings: SensorSettingsBase
@@ -603,12 +606,9 @@ class Sensor(ProtectAdoptableDeviceModel):
     # TODO:
     # mountType
 
-    PROTECT_OBJ_FIELDS: ClassVar[Dict[str, Callable]] = {  # type: ignore
-        "alarmSettings": SensorSettingsBase,
-        "batteryStatus": SensorBatteryStatus,
-    }
-
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {**ProtectAdoptableDeviceModel.UNIFI_REMAP, **{"camera": "cameraId"}}
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "camera": "cameraId"}
 
     @property
     def camera(self) -> Optional[Camera]:

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -64,13 +64,13 @@ class Event(ProtectModelWithId):
         }
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "start" in data:
             data["start"] = process_datetime(data, "start")
         if "end" in data:
             data["end"] = process_datetime(data, "end")
 
-        return super().clean_unifi_dict(data)
+        return super().unifi_dict_to_dict(data)
 
     @property
     def camera(self) -> Optional[Camera]:
@@ -287,11 +287,11 @@ class DoorbellSettings(ProtectBaseObject):
         return {**super()._get_unifi_remaps(), "defaultMessageResetTimeoutMs": "defaultMessageResetTimeout"}
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "defaultMessageResetTimeoutMs" in data:
             data["defaultMessageResetTimeout"] = timedelta(milliseconds=data.pop("defaultMessageResetTimeoutMs"))
 
-        return super().clean_unifi_dict(data)
+        return super().unifi_dict_to_dict(data)
 
 
 class RecordingTypeDistribution(ProtectBaseObject):
@@ -381,7 +381,7 @@ class NVR(ProtectDeviceModel):
         return {**super()._get_unifi_remaps(), "recordingRetentionDurationMs": "recordingRetentionDuration"}
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "lastUpdateAt" in data:
             data["lastUpdateAt"] = process_datetime(data, "lastUpdateAt")
         if "recordingRetentionDurationMs" in data:
@@ -389,7 +389,7 @@ class NVR(ProtectDeviceModel):
         if "timezone" in data and not isinstance(data["timezone"], tzinfo):
             data["timezone"] = pytz.timezone(data["timezone"])
 
-        data = super().clean_unifi_dict(data)
+        data = super().unifi_dict_to_dict(data)
 
         return data
 
@@ -462,7 +462,7 @@ class Bootstrap(ProtectBaseObject):
     events: Dict[str, Event] = FixSizeOrderedDict()
 
     @classmethod
-    def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         for model_type in ModelType.bootstrap_models():
             key = model_type + "s"
             items: Dict[str, ProtectModel] = {}
@@ -470,7 +470,7 @@ class Bootstrap(ProtectBaseObject):
                 items[item["id"]] = item
             data[key] = items
 
-        return super().clean_unifi_dict(data)
+        return super().unifi_dict_to_dict(data)
 
     def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, tzinfo
 from ipaddress import IPv4Address
 import logging
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Set
+from typing import Any, Dict, List, Literal, Optional, Set
 from uuid import UUID
 
 from pydantic.fields import PrivateAttr
@@ -42,7 +42,7 @@ class Event(ProtectModelWithId):
     heatmap_id: Optional[str]
     camera_id: Optional[str]
     smart_detect_types: List[SmartDetectObjectType]
-    smart_detect_events_ids: List[str]
+    smart_detect_event_ids: List[str]
     thumbnail_id: Optional[str]
     user_id: Optional[str]
 
@@ -52,16 +52,16 @@ class Event(ProtectModelWithId):
 
     _smart_detect_events: Optional[List[Event]] = PrivateAttr(None)
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {
-        **ProtectModelWithId.UNIFI_REMAP,
-        **{
-            "heatmap": "heatmapId",
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {
+            **super()._get_unifi_remaps(),
             "camera": "cameraId",
-            "smartDetectEvents": "smartDetectEventsIds",
-            "thumbnail": "thumbnailId",
+            "heatmap": "heatmapId",
             "user": "userId",
-        },
-    }
+            "thumbnail": "thumbnailId",
+            "smartDetectEvents": "smartDetectEventIds",
+        }
 
     @classmethod
     def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -92,7 +92,7 @@ class Event(ProtectModelWithId):
             return self._smart_detect_events
 
         self._smart_detect_events = [
-            self.api.bootstrap.events[g] for g in self.smart_detect_events_ids if g in self.api.bootstrap.events
+            self.api.bootstrap.events[g] for g in self.smart_detect_event_ids if g in self.api.bootstrap.events
         ]
         return self._smart_detect_events
 
@@ -127,12 +127,9 @@ class CloudAccount(ProtectModelWithId):
     # TODO:
     # profileImg
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {
-        **ProtectModelWithId.UNIFI_REMAP,
-        **{
-            "user": "userId",
-        },
-    }
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "user": "userId"}
 
     def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)
@@ -175,9 +172,11 @@ class User(ProtectModelWithId):
     # alertRules
     # notificationsV2
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {**ProtectModelWithId.UNIFI_REMAP, **{"groups": "groupIds"}}
-
     _groups: Optional[List[Group]] = PrivateAttr(None)
+
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "groups": "groupIds"}
 
     @property
     def groups(self) -> List[Group]:
@@ -215,10 +214,13 @@ class PortConfig(ProtectBaseObject):
     ucore: int
     discovery_client: int
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {
-        "emsCLI": "emsCli",
-        "emsLiveFLV": "emsLiveFlv",
-    }
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {
+            **super()._get_unifi_remaps(),
+            "emsCLI": "emsCli",
+            "emsLiveFLV": "emsLiveFlv",
+        }
 
 
 class CPUInfo(ProtectBaseObject):
@@ -280,7 +282,9 @@ class DoorbellSettings(ProtectBaseObject):
     # TODO
     # customMessages
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {"defaultMessageResetTimeoutMs": "defaultMessageResetTimeout"}
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "defaultMessageResetTimeoutMs": "defaultMessageResetTimeout"}
 
     @classmethod
     def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -372,10 +376,9 @@ class NVR(ProtectDeviceModel):
     # smartDetectAgreement
     # ssoChannel
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {
-        **ProtectDeviceModel.UNIFI_REMAP,
-        **{"recordingRetentionDurationMs": "recordingRetentionDuration"},
-    }
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "recordingRetentionDurationMs": "recordingRetentionDuration"}
 
     @classmethod
     def clean_unifi_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -398,7 +401,9 @@ class LiveviewSlot(ProtectBaseObject):
 
     _cameras: Optional[List[Camera]] = PrivateAttr(None)
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {"cameras": "cameraIds"}
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "cameras": "cameraIds"}
 
     @property
     def cameras(self) -> List[Camera]:
@@ -417,7 +422,9 @@ class Liveview(ProtectModelWithId):
     slots: List[LiveviewSlot]
     owner_id: str
 
-    UNIFI_REMAP: ClassVar[Dict[str, str]] = {**ProtectModelWithId.UNIFI_REMAP, **{"owner": "ownerId"}}
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "owner": "ownerId"}
 
     @property
     def owner(self) -> Optional[User]:


### PR DESCRIPTION
When trying to make everything be able to use construct, I kept running into issues with how I was handled child `ProtectBaseObject` attributes. This is a big refactor to start handling them all automatically instead of trying to manually manage them, which was a nightmare. 

This also supports attributes that have many child `ProtectBaseObject` values (lists / dicts) which there was no real support for before.