### PR TITLE
Updates ProtectBaseObject to use construct instead of normal pydantic constructor

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -27,3 +27,6 @@ disallow_untyped_calls = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 check_untyped_defs = false
+
+[mypy-pytest_benchmark.fixture]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,8 @@ good-names = [
 # wrong-import-order - isort guards this
 
 # handled by mypy:
-# no-member, unsupported-membership-test, unsupported-assignment-operation, unsubscriptable-object
+# no-member, unsupported-membership-test, unsupported-assignment-operation,
+# unsubscriptable-object, used-before-assignment
 disable = [
     "format",
     "abstract-class-little-used",
@@ -120,6 +121,7 @@ disable = [
     "unsupported-membership-test",
     "unsubscriptable-object",
     "unsupported-assignment-operation",
+    "used-before-assignment",
 ]
 enable = [
     #"useless-suppression",  # temporarily every now and then to clean them up

--- a/pyunifiprotect/data/__init__.py
+++ b/pyunifiprotect/data/__init__.py
@@ -1,4 +1,8 @@
-from pyunifiprotect.data.base import ProtectModel
+from pyunifiprotect.data.base import (
+    ProtectBaseObject,
+    ProtectModel,
+    create_from_unifi_dict,
+)
 from pyunifiprotect.data.devices import Camera, Light, Sensor, Viewer
 from pyunifiprotect.data.nvr import (
     NVR,
@@ -12,12 +16,15 @@ from pyunifiprotect.data.nvr import (
     UserLocation,
 )
 from pyunifiprotect.data.types import (
+    Color,
+    CoordType,
     DoorbellMessageType,
     EventType,
     FixSizeOrderedDict,
     LightModeEnableType,
     LightModeType,
     ModelType,
+    Percent,
     ProtectWSPayloadFormat,
     SmartDetectObjectType,
     StateType,
@@ -34,6 +41,9 @@ __all__ = [
     "Bootstrap",
     "Camera",
     "CloudAccount",
+    "Color",
+    "CoordType",
+    "create_from_unifi_dict",
     "DoorbellMessageType",
     "Event",
     "EventType",
@@ -46,6 +56,8 @@ __all__ = [
     "ModelType",
     "NVR",
     "NVRLocation",
+    "Percent",
+    "ProtectBaseObject",
     "ProtectModel",
     "ProtectWSPayloadFormat",
     "Sensor",

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -6,14 +6,13 @@ from ipaddress import IPv4Address
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 from uuid import UUID
 
-from pydantic.color import Color
-
 from pyunifiprotect.data.base import (
     ProtectAdoptableDeviceModel,
     ProtectBaseObject,
     ProtectMotionDeviceModel,
 )
 from pyunifiprotect.data.types import (
+    Color,
     DoorbellMessageType,
     LEDLevel,
     LightModeEnableType,
@@ -24,7 +23,12 @@ from pyunifiprotect.data.types import (
     SmartDetectObjectType,
     VideoMode,
 )
-from pyunifiprotect.utils import process_datetime, serialize_point, to_js_time
+from pyunifiprotect.utils import (
+    process_datetime,
+    round_decimal,
+    serialize_point,
+    to_js_time,
+)
 
 if TYPE_CHECKING:
     from pyunifiprotect.data.nvr import Event, Liveview
@@ -88,6 +92,15 @@ class EventStats(ProtectBaseObject):
     average: int
     last_days: List[int]
     recent_hours: List[int] = []
+
+    @classmethod
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        data = super().unifi_dict_to_dict(data)
+
+        if "recent_hours" not in data:
+            data["recent_hours"] = []
+
+        return data
 
     def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)
@@ -372,6 +385,15 @@ class CameraZone(ProtectBaseObject):
     name: str
     color: Color
     points: List[Tuple[Percent, Percent]]
+
+    @classmethod
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        data = super().unifi_dict_to_dict(data)
+
+        if "points" in data and isinstance(data["points"], list):
+            data["points"] = [(round_decimal(p[0], 4), round_decimal(p[1], 4)) for p in data["points"]]
+
+        return data
 
     def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -16,6 +16,7 @@ from pyunifiprotect.data.base import (
     ProtectDeviceModel,
     ProtectModel,
     ProtectModelWithId,
+    create_from_unifi_dict,
 )
 from pyunifiprotect.data.devices import Bridge, Camera, Light, Sensor, Viewer
 from pyunifiprotect.data.types import (
@@ -487,7 +488,7 @@ class Bootstrap(ProtectBaseObject):
 
     @property
     def auth_user(self) -> User:
-        user: User = self._api.bootstrap.users[self.auth_user_id]
+        user: User = self.api.bootstrap.users[self.auth_user_id]
         return user
 
     def process_event(self, event: Event) -> None:
@@ -528,7 +529,7 @@ class Bootstrap(ProtectBaseObject):
             return
 
         if action["action"] == "add":
-            obj = ProtectModel.from_unifi_dict(data, api=self._api)
+            obj = create_from_unifi_dict(data, api=self._api)
 
             if isinstance(obj, Event):
                 self.process_event(obj)

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import enum
-from typing import TYPE_CHECKING, Any, Generic, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, List, Optional, TypeVar, Union
 
 from pydantic import ConstrainedDecimal, ConstrainedInt
+from pydantic.color import Color as BaseColor
 
 KT = TypeVar("KT")
 VT = TypeVar("VT")
@@ -178,3 +179,14 @@ class Percent(ConstrainedDecimal):
     le = 1
     max_digits = 4
     decimal_places = 3
+
+
+CoordType = Union[Percent, int, float]
+
+
+class Color(BaseColor):
+    def __eq__(self, o: Any) -> bool:
+        if isinstance(o, Color):
+            return self.as_hex() == o.as_hex()
+
+        return super().__eq__(o)

--- a/pyunifiprotect/test_util/__init__.py
+++ b/pyunifiprotect/test_util/__init__.py
@@ -1,7 +1,7 @@
 # pylint: disable=protected-access
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, overload
@@ -157,7 +157,7 @@ class SampleDataGenerator:
                 heatmap_event: Dict[str, Any] = event
 
         data = self.write_json_file("sample_raw_events", data)
-        self.constants["time"] = datetime.now().isoformat()
+        self.constants["time"] = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
         self.constants["event_count"] = len(data)
 
         # populate event data in devices

--- a/pyunifiprotect/unifi_protect_server.py
+++ b/pyunifiprotect/unifi_protect_server.py
@@ -1169,7 +1169,7 @@ class ProtectApiClient(BaseApiClient):
         verify_ssl: bool = True,
         session: Optional[aiohttp.ClientSession] = None,
         minimum_score: int = 0,
-        debug: bool = False
+        debug: bool = False,
     ) -> None:
         super().__init__(
             host=host, port=port, username=username, password=password, verify_ssl=verify_ssl, session=session

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,9 +4,11 @@
 #
 #    pip-compile --extra=shell --output-file=requirements_all.txt setup.cfg
 #
-aiohttp==3.7.4.post0
+aiohttp==3.8.0
     # via pyunifiprotect (setup.cfg)
-async-timeout==3.0.1
+aiosignal==1.2.0
+    # via aiohttp
+async-timeout==4.0.0
     # via aiohttp
 asyncio==3.4.3
     # via pyunifiprotect (setup.cfg)
@@ -14,12 +16,16 @@ attrs==21.2.0
     # via aiohttp
 backcall==0.2.0
     # via ipython
-chardet==4.0.0
+charset-normalizer==2.0.7
     # via aiohttp
 click==8.0.3
     # via typer
 decorator==5.1.0
     # via ipython
+frozenlist==1.2.0
+    # via
+    #   aiohttp
+    #   aiosignal
 idna==3.3
     # via yarl
 ipython==7.29.0
@@ -64,11 +70,11 @@ typer==0.4.0
     # via pyunifiprotect (setup.cfg)
 typing-extensions==3.10.0.2
     # via
-    #   aiohttp
+    #   async-timeout
     #   pydantic
 wcwidth==0.2.5
     # via prompt-toolkit
-yarl==1.7.0
+yarl==1.7.2
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,11 +4,13 @@
 #
 #    pip-compile --extra=dev --output-file=requirements_test.txt --pip-args='-c requirements_all.txt' setup.cfg
 #
-aiohttp==3.7.4.post0
+aiohttp==3.8.0
     # via pyunifiprotect (setup.cfg)
+aiosignal==1.2.0
+    # via aiohttp
 astroid==2.8.4
     # via pylint
-async-timeout==3.0.1
+async-timeout==4.0.0
     # via aiohttp
 asyncio==3.4.3
     # via pyunifiprotect (setup.cfg)
@@ -22,18 +24,18 @@ backports.entry-points-selectable==1.1.0
     # via virtualenv
 base36==0.1.1
     # via pyunifiprotect (setup.cfg)
-black==21.9b0
+black==21.10b0
     # via pyunifiprotect (setup.cfg)
 build==0.7.0
     # via pyunifiprotect (setup.cfg)
-chardet==4.0.0
+charset-normalizer==2.0.7
     # via aiohttp
 click==8.0.3
     # via
     #   black
     #   pip-tools
     #   typer
-coverage[toml]==6.1
+coverage[toml]==6.1.1
     # via
     #   pytest-cov
     #   pyunifiprotect (setup.cfg)
@@ -52,6 +54,10 @@ flake8==4.0.1
     #   pyunifiprotect (setup.cfg)
 flake8-docstrings==1.6.0
     # via pyunifiprotect (setup.cfg)
+frozenlist==1.2.0
+    # via
+    #   aiohttp
+    #   aiosignal
 idna==3.3
     # via yarl
 iniconfig==1.1.1
@@ -119,6 +125,8 @@ py==1.10.0
     # via
     #   pytest
     #   tox
+py-cpuinfo==8.0.0
+    # via pytest-benchmark
 pycodestyle==2.8.0
     # via flake8
 pydantic==1.8.2
@@ -146,11 +154,14 @@ pyproject-flake8==0.0.1a2
 pytest==6.2.5
     # via
     #   pytest-asyncio
+    #   pytest-benchmark
     #   pytest-cov
     #   pytest-sugar
     #   pytest-timeout
     #   pyunifiprotect (setup.cfg)
 pytest-asyncio==0.16.0
+    # via pyunifiprotect (setup.cfg)
+pytest-benchmark==3.4.1
     # via pyunifiprotect (setup.cfg)
 pytest-cov==3.0.0
     # via pyunifiprotect (setup.cfg)
@@ -162,7 +173,7 @@ python-dotenv==0.19.1
     # via pyunifiprotect (setup.cfg)
 pytz==2021.3
     # via pyunifiprotect (setup.cfg)
-regex==2021.10.23
+regex==2021.11.2
     # via black
 six==1.16.0
     # via
@@ -203,11 +214,11 @@ types-termcolor==1.1.2
     # via pyunifiprotect (setup.cfg)
 typing-extensions==3.10.0.2
     # via
-    #   aiohttp
+    #   async-timeout
     #   black
     #   mypy
     #   pydantic
-virtualenv==20.9.0
+virtualenv==20.10.0
     # via tox
 wcwidth==0.2.5
     # via prompt-toolkit
@@ -215,7 +226,7 @@ wheel==0.37.0
     # via pip-tools
 wrapt==1.13.3
     # via astroid
-yarl==1.7.0
+yarl==1.7.2
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ dev =
     pyproject-flake8
     pytest
     pytest-asyncio
+    pytest-benchmark
     pytest-cov
     pytest-sugar
     pytest-timeout>=1.2.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import pytest
 
 from pyunifiprotect import ProtectApiClient, UpvServer
 from pyunifiprotect.data import ModelType
+from pyunifiprotect.utils import set_debug, set_no_debug
 from tests.sample_data.constants import CONSTANTS
 
 UFP_SAMPLE_DIR = os.environ.get("UFP_SAMPLE_DIR")
@@ -87,6 +88,11 @@ MockDatetime = Mock()
 MockDatetime.now.return_value = get_now()
 
 
+@pytest.fixture(autouse=True)
+def ensure_debug():
+    set_debug()
+
+
 @pytest.fixture
 @pytest.mark.asyncio
 async def old_protect_client():
@@ -128,7 +134,25 @@ async def protect_client():
 
 @pytest.fixture
 @pytest.mark.asyncio
+async def protect_client_no_debug():
+    set_no_debug()
+
+    client = ProtectApiClient("127.0.0.1", 0, "username", "password")
+    client.is_unifi_os = False
+    client.api_request = AsyncMock(side_effect=mock_api_request)
+    client.api_request_raw = AsyncMock(side_effect=mock_api_request_raw)
+    client.ensure_authenticated = AsyncMock()
+
+    await client.update(True)
+
+    yield client
+
+
+@pytest.fixture
+@pytest.mark.asyncio
 async def protect_client_ws():
+    set_no_debug()
+
     client = ProtectApiClient("127.0.0.1", 0, "username", "password")
     client.is_unifi_os = True
     client.api_request = AsyncMock(side_effect=mock_api_request)

--- a/tests/sample_data/sample_constants.json
+++ b/tests/sample_data/sample_constants.json
@@ -19,7 +19,7 @@
         "chime": 0,
         "schedule": 0
     },
-    "time": "2021-10-18T00:07:17.748398",
+    "time": "2021-10-18T00:07:17.748398+00:00",
     "event_count": 785,
     "camera_thumbnail": "e-ed92bd8337974040dd4711d2",
     "camera_online": true

--- a/tests/test_unifi_protect_server.py
+++ b/tests/test_unifi_protect_server.py
@@ -60,6 +60,41 @@ async def test_bootstrap(protect_client: ProtectApiClient):
 
 
 @pytest.mark.asyncio
+async def test_bootstrap_construct(protect_client_no_debug: ProtectApiClient):
+    """Verifies lookup of all object via ID"""
+
+    protect_client = protect_client_no_debug
+    assert protect_client.bootstrap.auth_user
+
+    for light in protect_client.bootstrap.lights.values():
+        light.camera
+        light.last_motion_event
+
+    for camera in protect_client.bootstrap.cameras.values():
+        camera.last_motion_event
+        camera.last_ring_event
+        camera.last_smart_detect_event
+
+    for viewer in protect_client.bootstrap.viewers.values():
+        assert viewer.liveview
+
+    for liveview in protect_client.bootstrap.liveviews.values():
+        liveview.owner
+
+        for slot in liveview.slots:
+            assert len(slot.camera_ids) == len(slot.cameras)
+
+    for user in protect_client.bootstrap.users.values():
+        user.groups
+
+        if user.cloud_account is not None:
+            assert user.cloud_account.user == user
+
+    for event in protect_client.bootstrap.events.values():
+        event.smart_detect_events
+
+
+@pytest.mark.asyncio
 @patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
 async def test_get_events_raw_default(protect_client: ProtectApiClient, now: datetime):
     events = await protect_client.get_events_raw()

--- a/tests/test_unifi_protect_server_ws.py
+++ b/tests/test_unifi_protect_server_ws.py
@@ -28,16 +28,18 @@ def packet():
 
 @pytest.mark.asyncio
 async def test_ws_all(protect_client_ws: ProtectApiClient, ws_messages: Dict[str, Dict[str, Any]]):
+    protect_client = protect_client_ws
+
     # wait for ws connection
     for _ in range(60):
-        if protect_client_ws.ws_connection is not None:
+        if protect_client.ws_connection is not None:
             break
         await asyncio.sleep(0.5)
 
-    ws_connect: Optional[MockWebsocket] = protect_client_ws.ws_connection  # type: ignore
+    ws_connect: Optional[MockWebsocket] = protect_client.ws_connection  # type: ignore
     assert ws_connect is not None
 
-    while protect_client_ws.ws_connection is not None:
+    while protect_client.ws_connection is not None:
         await asyncio.sleep(0.1)
 
     assert ws_connect.count == len(ws_messages)
@@ -46,7 +48,9 @@ async def test_ws_all(protect_client_ws: ProtectApiClient, ws_messages: Dict[str
 
 @pytest.mark.asyncio
 @patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
-async def test_ws_event_ring(protect_client: ProtectApiClient, now, camera, packet: WSPacket):
+async def test_ws_event_ring(protect_client_no_debug: ProtectApiClient, now, camera, packet: WSPacket):
+    protect_client = protect_client_no_debug
+
     def get_camera():
         return protect_client.bootstrap.cameras[camera["id"]]
 
@@ -109,7 +113,9 @@ async def test_ws_event_ring(protect_client: ProtectApiClient, now, camera, pack
 
 @pytest.mark.asyncio
 @patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
-async def test_ws_event_motion_in_progress(protect_client: ProtectApiClient, now, camera, packet: WSPacket):
+async def test_ws_event_motion_in_progress(protect_client_no_debug: ProtectApiClient, now, camera, packet: WSPacket):
+    protect_client = protect_client_no_debug
+
     def get_camera():
         return protect_client.bootstrap.cameras[camera["id"]]
 
@@ -206,7 +212,9 @@ async def test_ws_event_motion_in_progress(protect_client: ProtectApiClient, now
 
 @pytest.mark.asyncio
 @patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
-async def test_ws_event_motion(protect_client: ProtectApiClient, now, camera, packet: WSPacket):
+async def test_ws_event_motion(protect_client_no_debug: ProtectApiClient, now, camera, packet: WSPacket):
+    protect_client = protect_client_no_debug
+
     def get_camera():
         return protect_client.bootstrap.cameras[camera["id"]]
 
@@ -272,7 +280,9 @@ async def test_ws_event_motion(protect_client: ProtectApiClient, now, camera, pa
 
 @pytest.mark.asyncio
 @patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
-async def test_ws_event_smart(protect_client: ProtectApiClient, now, camera, packet: WSPacket):
+async def test_ws_event_smart(protect_client_no_debug: ProtectApiClient, now, camera, packet: WSPacket):
+    protect_client = protect_client_no_debug
+
     def get_camera():
         return protect_client.bootstrap.cameras[camera["id"]]
 
@@ -336,7 +346,9 @@ async def test_ws_event_smart(protect_client: ProtectApiClient, now, camera, pac
 
 @pytest.mark.asyncio
 @patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
-async def test_ws_event_update(protect_client: ProtectApiClient, now, camera, packet: WSPacket):
+async def test_ws_event_update(protect_client_no_debug: ProtectApiClient, now, camera, packet: WSPacket):
+    protect_client = protect_client_no_debug
+
     def get_camera() -> Camera:
         return protect_client.bootstrap.cameras[camera["id"]]
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,10 @@ python =
 deps =
     -r{toxinidir}/requirements_test.txt
 commands =
-    pytest --force-sugar --timeout=30 --cov-report term {posargs}
+    pytest --force-sugar --timeout=30 --cov-report term {posargs} --color=yes tests/test_data.py
 setenv =
     PYTHONPATH = {toxinidir}
+    FORCE_COLOR = 1
 
 [testenv:lint]
 #basepython = {env:PYTHON3_PATH:python3}


### PR DESCRIPTION
The main goal of this is to remove Pydantic's hard runtime type enforcement when creating objects from JSON that comes from UFP. Runtime type enforcement will still be applied to manual updates to UFP objects. To enable type enforcement for UFP JSON, set the ENV `UFP_DEBUG=True`

* Removes `klass_from_dict` and `from_unifi_dict` out of `ProtectBaseObject` and made them separate methods.
* Changed `__init__` to not run `unifi_dict_to_dict`
* Adds `from_unifi_dict` that runs `unifi_dict_to_dict` and then chooses between `__init__` and `construct` based on ENV variable
* Adds support for construct generating the same object structure as `__init__`
* Adds `convert_unifi_data` to take a pydantic field and automatically convert the passed in value to the correct type (usually just passing the raw value into the class constructor)
* Fixes comparison of pydantic's Color objects
* Adds new tests to benchmark `__init__` vs. `construct`.
   * `construct` is _slightly_ faster, but not a significant amount. They are both about the same performance. 
* Forces all color output for pytest for GHA.

## HA Install Link:

```
git+https://github.com/AngellusMortis/pyunifiprotect.git@feature/pydantic-construct#pyunifiprotect==0.35.7
```