### PR TITLE
Adds PEP 561 typing metadata

### DIFF
--- a/pyunifiprotect/unifi_protect_server.py
+++ b/pyunifiprotect/unifi_protect_server.py
@@ -1160,8 +1160,19 @@ class ProtectApiClient(BaseApiClient):
     _bootstrap: Optional[Bootstrap] = None
     _last_update_dt: Optional[datetime] = None
 
-    def __init__(self, *args: Any, minimum_score: int = 0, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        username: str,
+        password: str,
+        verify_ssl: bool = True,
+        session: Optional[aiohttp.ClientSession] = None,
+        minimum_score: int = 0,
+    ) -> None:
+        super().__init__(
+            host=host, port=port, username=username, password=password, verify_ssl=verify_ssl, session=session
+        )
 
         self._minimum_score = minimum_score
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
 
 [options]
 packages = find:
+include_package_data = True
 install_requires =
     aiohttp
     asyncio
@@ -28,6 +29,9 @@ install_requires =
     python-dotenv
     pytz
     typer
+
+[options.package_data]
+pyunifiprotect = py.typed
 
 [options.packages.find]
 exclude=


### PR DESCRIPTION
* Adds metadata needed so type hints are exported for the package when installed.
* Fixes args for `ProtectApiClient` so they appear in type hints correctly.