### PR TITLE
Adds pythonPath settings in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,7 @@
         "files.trimTrailingWhitespace": true,
         "python.envFile": "${workspaceFolder}/.env",
         "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.pythonPath": "/usr/local/bin/python",
         "python.formatting.blackArgs": [
             "--line-length",
             "120"


### PR DESCRIPTION
`defaultInterpreterPath` I thought was suppose to be a replacement for `pythonPath`, but `pythonPath` still exists, so have both to ensure no issues using VS Code setup.