### PR TITLE
Adds WS Subscriptions to new API Client

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -420,7 +420,10 @@ class ProtectApiClient(BaseApiClient):
             return
 
         for sub in self._ws_subscriptions:
-            sub(processed_message)
+            try:
+                sub(processed_message)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Exception while running subscription handler")
 
     @property
     def bootstrap(self) -> Bootstrap:

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -17,6 +17,7 @@ from yarl import URL
 
 from pyunifiprotect.data import Event, EventType, WSPacket, create_from_unifi_dict
 from pyunifiprotect.data.bootstrap import Bootstrap
+from pyunifiprotect.data.websocket import WSSubscriptionMessage
 from pyunifiprotect.exceptions import BadRequest, NotAuthorized, NvrError
 from pyunifiprotect.utils import get_response_reason, set_debug, to_js_time
 
@@ -359,6 +360,7 @@ class ProtectApiClient(BaseApiClient):
     _minimum_score: int
     _bootstrap: Optional[Bootstrap] = None
     _last_update_dt: Optional[datetime] = None
+    _ws_subscriptions: List[Callable[[WSSubscriptionMessage], None]] = []
 
     def __init__(
         self,
@@ -412,7 +414,13 @@ class ProtectApiClient(BaseApiClient):
 
     def _process_ws_message(self, msg: aiohttp.WSMessage) -> None:
         packet = WSPacket(msg.data)
-        self.bootstrap.process_ws_packet(packet)
+        processed_message = self.bootstrap.process_ws_packet(packet)
+
+        if processed_message is None:
+            return
+
+        for sub in self._ws_subscriptions:
+            sub(processed_message)
 
     @property
     def bootstrap(self) -> Bootstrap:
@@ -498,3 +506,17 @@ class ProtectApiClient(BaseApiClient):
                 events.append(event)
 
         return events
+
+    def subscribe_websocket(self, ws_callback: Callable[[WSSubscriptionMessage], None]) -> Callable[[], None]:
+        """
+        Subscribe to websocket events.
+
+        Returns a callback that will unsubscribe.
+        """
+
+        def _unsub_ws_callback() -> None:
+            self._ws_subscriptions.remove(ws_callback)
+
+        _LOGGER.debug("Adding subscription: %s", ws_callback)
+        self._ws_subscriptions.append(ws_callback)
+        return _unsub_ws_callback

--- a/pyunifiprotect/data/__init__.py
+++ b/pyunifiprotect/data/__init__.py
@@ -28,10 +28,12 @@ from pyunifiprotect.data.types import (
 )
 from pyunifiprotect.data.websocket import (
     WS_HEADER_SIZE,
+    WSAction,
     WSJSONPacketFrame,
     WSPacket,
     WSPacketFrameHeader,
     WSRawPacketFrame,
+    WSSubscriptionMessage,
 )
 
 __all__ = [
@@ -64,8 +66,10 @@ __all__ = [
     "UserLocation",
     "Viewer",
     "WS_HEADER_SIZE",
+    "WSAction",
     "WSJSONPacketFrame",
     "WSPacket",
     "WSPacketFrameHeader",
     "WSRawPacketFrame",
+    "WSSubscriptionMessage",
 ]

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -363,11 +363,6 @@ class ProtectBaseObject(BaseModel):
         new_data["api"] = self._api
         return self.construct(**new_data)  # type: ignore
 
-    def update_from_unifi_dict(self: ProtectObject, data: Dict[str, Any]) -> ProtectObject:
-        """Updates current object from an uncleaned UFP JSON dict"""
-        data = self.unifi_dict_to_dict(data)
-        return self.update_from_dict(data)
-
     @property
     def api(self) -> ProtectApiClient:
         """

--- a/pyunifiprotect/data/websocket.py
+++ b/pyunifiprotect/data/websocket.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 
 import base64
 from dataclasses import dataclass
+import enum
 import json
 import struct
 from typing import Any, Dict, Optional, Type
+from uuid import UUID
 import zlib
 
+from pyunifiprotect.data.base import ProtectModel
 from pyunifiprotect.data.types import ProtectWSPayloadFormat
 from pyunifiprotect.exceptions import WSDecodeError, WSEncodeError
 
@@ -21,6 +24,21 @@ class WSPacketFrameHeader:
     deflated: int
     unknown: int
     payload_size: int
+
+
+@enum.unique
+class WSAction(str, enum.Enum):
+    ADD = "add"
+    UPDATE = "update"
+
+
+@dataclass
+class WSSubscriptionMessage:
+    action: WSAction
+    new_update_id: UUID
+    changed_data: Dict[str, Any]
+    new_obj: ProtectModel
+    old_obj: Optional[ProtectModel] = None
 
 
 class BaseWSPacketFrame:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -94,7 +94,7 @@ async def test_bootstrap_construct(protect_client_no_debug: ProtectApiClient):
 
 
 @pytest.mark.asyncio
-@patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
+@patch("pyunifiprotect.api.datetime", MockDatetime)
 async def test_get_events_raw_default(protect_client: ProtectApiClient, now: datetime):
     events = await protect_client.get_events_raw()
 

--- a/tests/test_api_polling.py
+++ b/tests/test_api_polling.py
@@ -31,7 +31,7 @@ async def test_process_events_none(protect_client: ProtectApiClient, camera):
 
 
 @pytest.mark.asyncio
-@patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
+@patch("pyunifiprotect.api.datetime", MockDatetime)
 async def test_process_events_ring(protect_client: ProtectApiClient, now, camera):
     def get_camera():
         return protect_client.bootstrap.cameras[camera["id"]]
@@ -90,7 +90,7 @@ async def test_process_events_ring(protect_client: ProtectApiClient, now, camera
 
 
 @pytest.mark.asyncio
-@patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
+@patch("pyunifiprotect.api.datetime", MockDatetime)
 async def test_process_events_motion_in_progress(protect_client: ProtectApiClient, now, camera):
     def get_camera():
         return protect_client.bootstrap.cameras[camera["id"]]
@@ -140,7 +140,7 @@ async def test_process_events_motion_in_progress(protect_client: ProtectApiClien
 
 
 @pytest.mark.asyncio
-@patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
+@patch("pyunifiprotect.api.datetime", MockDatetime)
 async def test_process_events_motion(protect_client: ProtectApiClient, now, camera):
     def get_camera():
         return protect_client.bootstrap.cameras[camera["id"]]
@@ -202,7 +202,7 @@ async def test_process_events_motion(protect_client: ProtectApiClient, now, came
 
 
 @pytest.mark.asyncio
-@patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
+@patch("pyunifiprotect.api.datetime", MockDatetime)
 async def test_process_events_smart(protect_client: ProtectApiClient, now, camera):
     def get_camera():
         return protect_client.bootstrap.cameras[camera["id"]]

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -74,7 +74,7 @@ async def test_ws_all(protect_client_ws: ProtectApiClient, ws_messages: Dict[str
 
 
 @pytest.mark.asyncio
-@patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
+@patch("pyunifiprotect.api.datetime", MockDatetime)
 async def test_ws_event_ring(protect_client_no_debug: ProtectApiClient, now, camera, packet: WSPacket):
     protect_client = protect_client_no_debug
 
@@ -139,7 +139,7 @@ async def test_ws_event_ring(protect_client_no_debug: ProtectApiClient, now, cam
 
 
 @pytest.mark.asyncio
-@patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
+@patch("pyunifiprotect.api.datetime", MockDatetime)
 async def test_ws_event_motion_in_progress(protect_client_no_debug: ProtectApiClient, now, camera, packet: WSPacket):
     protect_client = protect_client_no_debug
 
@@ -238,7 +238,7 @@ async def test_ws_event_motion_in_progress(protect_client_no_debug: ProtectApiCl
 
 
 @pytest.mark.asyncio
-@patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
+@patch("pyunifiprotect.api.datetime", MockDatetime)
 async def test_ws_event_motion(protect_client_no_debug: ProtectApiClient, now, camera, packet: WSPacket):
     protect_client = protect_client_no_debug
 
@@ -306,7 +306,7 @@ async def test_ws_event_motion(protect_client_no_debug: ProtectApiClient, now, c
 
 
 @pytest.mark.asyncio
-@patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
+@patch("pyunifiprotect.api.datetime", MockDatetime)
 async def test_ws_event_smart(protect_client_no_debug: ProtectApiClient, now, camera, packet: WSPacket):
     protect_client = protect_client_no_debug
 
@@ -372,7 +372,7 @@ async def test_ws_event_smart(protect_client_no_debug: ProtectApiClient, now, ca
 
 
 @pytest.mark.asyncio
-@patch("pyunifiprotect.unifi_protect_server.datetime", MockDatetime)
+@patch("pyunifiprotect.api.datetime", MockDatetime)
 async def test_ws_event_update(protect_client_no_debug: ProtectApiClient, now, camera, packet: WSPacket):
     protect_client = protect_client_no_debug
 


### PR DESCRIPTION
The new subscriptions uses a new message class:

```python
class WSSubscriptionMessage:
    action: WSAction
    new_update_id: UUID
    changed_data: Dict[str, Any]
    new_obj: ProtectModel
    old_obj: Optional[ProtectModel] = None
```

The fields are pretty straight forward:

* `old_obj` is `None` if `action` is `ADD`
* `old_obj` + `changed_data` = `new_obj` 

I am not a big fan of `changed_data` being a raw dict, but it is the already posted "cleaned" data so the keys match up with the attrs perfectly.