### PR TITLE
Adds set_speaker_volume to cameras

### DIFF
--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -719,6 +719,15 @@ class Camera(ProtectMotionDeviceModel):
         self.mic_volume = level
         await self.save_device()
 
+    async def set_speaker_volume(self, level: PercentInt) -> None:
+        """Sets the speaker sensitivity level on camera"""
+
+        if not self.feature_flags.has_speaker:
+            raise BadRequest("Camera does not have speaker")
+
+        self.speaker_settings.volume = level
+        await self.save_device()
+
     async def set_chime_duration(self, duration: ChimeDuration) -> None:
         """Sets chime duration for doorbell. Requires camera to be a doorbell"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,6 +279,16 @@ async def camera_with_mic_obj(protect_client: ProtectApiClient):  # pylint: disa
 
 @pytest.fixture
 @pytest.mark.asyncio
+async def camera_with_speaker_obj(protect_client: ProtectApiClient):  # pylint: disable=redefined-outer-name
+    for c in protect_client.bootstrap.cameras.values():
+        if c.feature_flags.has_speaker:
+            return c
+
+    return None
+
+
+@pytest.fixture
+@pytest.mark.asyncio
 async def camera_with_privacy_obj(protect_client: ProtectApiClient):  # pylint: disable=redefined-outer-name
     for c in protect_client.bootstrap.cameras.values():
         if c.feature_flags.has_privacy_mask:

--- a/tests/test_data_updates.py
+++ b/tests/test_data_updates.py
@@ -314,6 +314,33 @@ async def test_camera_set_mic_volume(camera_with_mic_obj: Optional[Camera], leve
         )
 
 
+@pytest.mark.parametrize("level", [-1, 0, 100, 200])
+@pytest.mark.asyncio
+async def test_camera_set_speaker_volume(camera_with_speaker_obj: Optional[Camera], level: int):
+    camera = camera_with_speaker_obj
+    if camera is None:
+        pytest.skip("No Camera obj found")
+
+    camera.api.api_request.reset_mock()
+
+    camera.speaker_settings.volume = 10
+    camera._initial_data = camera.dict()  # pylint: disable=protected-access
+
+    if level in (-1, 200):
+        with pytest.raises(ValidationError):
+            await camera.set_speaker_volume(level)
+
+        assert not camera.api.api_request.called
+    else:
+        await camera.set_speaker_volume(level)
+
+        camera.api.api_request.assert_called_with(
+            f"cameras/{camera.id}",
+            method="patch",
+            json={"speakerSettings": {"volume": level}},
+        )
+
+
 @pytest.mark.asyncio
 async def test_camera_set_chime_duration_no_chime(camera_with_no_chime_obj: Optional[Camera]):
     camera = camera_with_no_chime_obj


### PR DESCRIPTION
@briis I split this out into a sperate PR to help you out adding new features to `pyunifiprotect`. We will need to able to control the output volume for the camera speakers for the `media_player` entities.

* Helper methods to update the device goes on the device class (in this case a camera).
    * I did a check for the feature flag that is required for the change to work (cannot change speaker volume if there are no speakers)
    * After you update the device class, call `.save_device` which will diff the object and then call `ProtectApiClient.update_device` which will do the `PATCH` to for the device like `UvpServer` did.
* You can write a test that verifies the `PATCH` request is what you expected from reverse engineering the change.
* Input validation is automatically done by `pydantic` via type hints 
    * For `speaker_settings.volume` it is a `PercentInt`, which is a `ContraintedInt`: https://pydantic-docs.helpmanual.io/usage/types/#strict-types for examples
    * See the test for what happens if you pass in invalid data.
    * A lot of the fields might still have Python base types (`int`, `str`, etc.). If you figure out validation for any additional fields, feel to make new types.

I am always free to help you figuring out if you need it!