### PR TITLE
Adds ability to play audio from URL to a camera via talkback settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode/settings.json
 test-data
 ufp-data
+*.mp3
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/pyunifiprotect/exceptions.py
+++ b/pyunifiprotect/exceptions.py
@@ -2,6 +2,10 @@ class UnifiProtectError(Exception):
     """Base class for all other Unifi Protect errors"""
 
 
+class StreamError(UnifiProtectError):
+    """Expcetion raised when trying to stream content"""
+
+
 class DataDecodeError(UnifiProtectError):
     """Exception raised when trying to decode a Unifi Protect object"""
 

--- a/pyunifiprotect/stream.py
+++ b/pyunifiprotect/stream.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from asyncio.subprocess import PIPE, Process, create_subprocess_exec
+from pathlib import Path
+from shlex import split
+from shutil import which
+from typing import TYPE_CHECKING, List, Optional
+
+from pyunifiprotect.exceptions import BadRequest, StreamError
+
+if TYPE_CHECKING:
+    from pyunifiprotect.data import Camera
+
+
+class FfmpegCommand:
+    ffmpeg_path: Path
+    args: List[str]
+    process: Optional[Process] = None
+
+    _stdout: Optional[List[str]] = None
+    _stderr: Optional[List[str]] = None
+
+    def __init__(self, cmd: str, ffmpeg_path: Optional[Path] = None) -> None:
+        self.args = split(cmd)
+
+        if "ffmpeg" in self.args[0]:
+            default_ffmpeg: Optional[str] = self.args.pop(0)
+        else:
+            default_ffmpeg = which("ffmpeg")
+
+        if default_ffmpeg is None:
+            raise StreamError("Could not find ffmpeg")
+
+        if ffmpeg_path is None:
+            self.ffmpeg_path = Path(default_ffmpeg)
+        else:
+            self.ffmpeg_path = ffmpeg_path
+
+    @property
+    def is_started(self) -> bool:
+        return self.process is not None
+
+    @property
+    def is_running(self) -> bool:
+        if self.process is None:
+            return False
+
+        return self.process.returncode is None
+
+    @property
+    def is_error(self) -> bool:
+        if self.process is None:
+            raise StreamError("ffmpeg has not started")
+
+        if self.is_running:
+            return False
+
+        return self.process.returncode != 0
+
+    async def get_output(self) -> List[str]:
+        if self._stdout is not None:
+            return self._stdout
+
+        if not self.is_error or self.process is None:
+            return []
+
+        if self.process.stdout is None:
+            stdout = b""
+        else:
+            stdout = await self.process.stdout.read()
+        self._stdout = stdout.decode("utf8").split("\n")
+
+        return self._stdout
+
+    async def get_errors(self) -> List[str]:
+        if self._stderr is not None:
+            return self._stderr
+
+        if not self.is_error or self.process is None:
+            return []
+
+        if self.process.stderr is None:
+            stderr = b""
+        else:
+            stderr = await self.process.stderr.read()
+        self._stderr = stderr.decode("utf8").split("\n")
+
+        return self._stderr
+
+    async def start(self) -> None:
+        if self.is_started:
+            raise StreamError("ffmpeg command already started")
+
+        if not self.ffmpeg_path.exists():
+            raise StreamError("Could not find ffmpeg")
+
+        self.process = await create_subprocess_exec(self.ffmpeg_path, *self.args, stdout=PIPE, stderr=PIPE)
+
+    async def stop(self) -> None:
+        if self.process is None:
+            raise StreamError("ffmpeg has not started")
+
+        self.process.kill()
+        await self.process.wait()
+
+    async def run_until_complete(self) -> None:
+        if self.is_started:
+            raise StreamError("ffmpeg command already started")
+
+        await self.start()
+        if self.process is None:
+            raise StreamError("Could not start stream")
+
+        await self.process.wait()
+
+
+class TalkbackStream(FfmpegCommand):
+    camera: Camera
+    content_url: str
+
+    def __init__(self, camera: Camera, content_url: str, ffmpeg_path: Optional[Path] = None):
+        if not camera.feature_flags.has_speaker:
+            raise BadRequest("Camera does not have a speaker for talkback")
+
+        input_args = self.get_args_from_url(content_url)
+        if len(input_args) > 0:
+            input_args += " "
+
+        cmd = f"-loglevel error -hide_banner {input_args}-i {content_url} -vn -acodec {camera.talkback_settings.type_fmt} -ac {camera.talkback_settings.channels} -ar {camera.talkback_settings.sampling_rate} -bits_per_raw_sample {camera.talkback_settings.bits_per_sample} -map 0:a -aq {camera.talkback_settings.quality} -f adts udp://{camera.host}:{camera.talkback_settings.bind_port}"
+
+        super().__init__(cmd, ffmpeg_path)
+
+    @classmethod
+    def get_args_from_url(cls, content_url: str) -> str:
+        # TODO:
+        return ""

--- a/pyunifiprotect/stream.py
+++ b/pyunifiprotect/stream.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from asyncio.subprocess import PIPE, Process, create_subprocess_exec
 from pathlib import Path
 from shlex import split
-from aioshutil import which
 from typing import TYPE_CHECKING, List, Optional
+
+from aioshutil import which
 
 from pyunifiprotect.exceptions import BadRequest, StreamError
 

--- a/pyunifiprotect/stream.py
+++ b/pyunifiprotect/stream.py
@@ -23,11 +23,8 @@ class FfmpegCommand:
     def __init__(self, cmd: str, ffmpeg_path: Optional[Path] = None) -> None:
         self.args = split(cmd)
 
-        if "ffmpeg" in self.args[0]:
-            default_ffmpeg: Optional[str] = self.args.pop(0)
-
-        if ffmpeg_path is None:
-            self.ffmpeg_path = Path(default_ffmpeg)
+        if "ffmpeg" in self.args[0] and ffmpeg_path is None:
+            self.ffmpeg_path = Path(self.args.pop(0))
         else:
             self.ffmpeg_path = ffmpeg_path
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,6 +6,8 @@
 #
 aiohttp==3.8.0
     # via pyunifiprotect (setup.cfg)
+aioshutil==1.1
+    # via pyunifiprotect (setup.cfg)
 aiosignal==1.2.0
     # via aiohttp
 async-timeout==4.0.0
@@ -46,7 +48,7 @@ pickleshare==0.7.5
     # via ipython
 pillow==8.4.0
     # via pyunifiprotect (setup.cfg)
-prompt-toolkit==3.0.21
+prompt-toolkit==3.0.22
     # via ipython
 ptyprocess==0.7.0
     # via pexpect

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,6 +6,8 @@
 #
 aiohttp==3.8.0
     # via pyunifiprotect (setup.cfg)
+aioshutil==1.1
+    # via pyunifiprotect (setup.cfg)
 aiosignal==1.2.0
     # via aiohttp
 astroid==2.8.4
@@ -64,7 +66,7 @@ iniconfig==1.1.1
     # via pytest
 ipython==7.29.0
     # via pyunifiprotect (setup.cfg)
-isort==5.9.3
+isort==5.10.0
     # via pylint
 jedi==0.18.0
     # via ipython
@@ -117,11 +119,11 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-prompt-toolkit==3.0.21
+prompt-toolkit==3.0.22
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
-py==1.10.0
+py==1.11.0
     # via
     #   pytest
     #   tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ packages = find:
 include_package_data = True
 install_requires =
     aiohttp
+    aioshutil
     asyncio
     pillow
     pydantic


### PR DESCRIPTION
* Adds ability to exclude fields from "changed" data for UFP objects (override `_get_excluded_changed_fields`)
* Adds `FfmpegCommand`: ffmpeg wrapper class to run ffmpeg commands. 
* Adds `TalkbackStream`: extends `FfmpegCommand` to play an input to a camera
* Adds `play_audio` to camera obj that wraps `TalkbackStream`

`play_audio`, `FfmpegCommand`, and `TalkbackStream` all obviously requires `ffmpeg` to use.

The way to test locally is to use the `unifi-protect shell` command:

```python
c = protect.bootstrap.cameras[id_of_camera_with_speaker]
await c.play_audio(path_to_mp3_file)
```