### PR TITLE
Optmize docstrings for VS Code

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -498,15 +498,17 @@ class ProtectApiClient(BaseApiClient):
         """
         Get list of events from Protect
 
-        :param start: start time for events
-        :param end: end time for events
-        :param limit: max number of events to return
-        :camera_ids: list of Cameras to get events for
+        Args:
 
-        If limit, start and end are not provided, it will default to all events in the last 24 hours.
+        * `start`: start time for events
+        * `end`: end time for events
+        * `limit`: max number of events to return
+        * `camera_ids`: list of Cameras to get events for
 
-        If start is provided, then end or limit must be provided. If end is provided, then start or
-        limit must be provided. Otherwise, you will get a 400 error from Unifi Protect
+        If `limit`, `start` and `end` are not provided, it will default to all events in the last 24 hours.
+
+        If `start` is provided, then `end` or `limit` must be provided. If `end` is provided, then `start` or
+        `limit` must be provided. Otherwise, you will get a 400 error from Unifi Protect
 
         Providing a list of Camera IDs will not prevent non-camera events from returning.
         """

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -75,8 +75,10 @@ class ProtectBaseObject(BaseModel):
         """
         Main constructor for `ProtectBaseObject`
 
-        :param api: Optional reference to the ProtectAPIClient that created generated the UFP JSON
-        :param data: decoded UFP JSON
+        Args:
+
+        * `api`: Optional reference to the ProtectAPIClient that created generated the UFP JSON
+        * `data`: decoded UFP JSON
 
         `api` is is expected as a `@property`. If it is `None` and accessed, a `BadRequest` will be raised.
 
@@ -228,7 +230,9 @@ class ProtectBaseObject(BaseModel):
         * Injects ProtectAPIClient into any child UFP object Dicts
         * Runs `.unifi_dict_to_dict` for any child UFP objects
 
-        :param data: decoded UFP JSON dict
+        Args:
+
+        * `data`: decoded UFP JSON dict
         """
 
         # get the API client instance
@@ -319,8 +323,10 @@ class ProtectBaseObject(BaseModel):
         * Automatically removes any ProtectApiClient instances that might still be in the data
         * Automaitcally calls `.unifi_dict()` for any UFP Python objects that are detected
 
-        :param data: Optional output of `.dict()` for the Python object. If `None`, will call `.dict` first
-        :param exclude: Optional set of fields to exclude from convert. Useful for subclassing and having custom
+        Args:
+
+        `data`: Optional output of `.dict()` for the Python object. If `None`, will call `.dict` first
+        `exclude`: Optional set of fields to exclude from convert. Useful for subclassing and having custom
             processing for dumping to UFP JSON data.
         """
 

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -797,8 +797,10 @@ class Camera(ProtectMotionDeviceModel):
 
         Requires ffmpeg to use.
 
-        :param content_url: Either a URL accessible by python or a path to a file (ffmepg's `-i` parameter)
-        :param ffmpeg_path: Optional path to ffmpeg binary
+        Args:
+
+        * `content_url`: Either a URL accessible by python or a path to a file (ffmepg's `-i` parameter)
+        * `ffmpeg_path`: Optional path to ffmpeg binary
 
         Use either `await stream.run_until_complete()` or `await stream.start()` to start subprocess command
         after getting the stream.
@@ -818,8 +820,10 @@ class Camera(ProtectMotionDeviceModel):
 
         Requires ffmpeg to use.
 
-        :param content_url: Either a URL accessible by python or a path to a file (ffmepg's `-i` parameter)
-        :param ffmpeg_path: Optional path to ffmpeg binary
+        Args:
+
+        * `content_url`: Either a URL accessible by python or a path to a file (ffmepg's `-i` parameter)
+        * `ffmpeg_path`: Optional path to ffmpeg binary
         """
 
         stream = self.create_talkback_stream(content_url, ffmpeg_path)
@@ -845,7 +849,13 @@ class Viewer(ProtectAdoptableDeviceModel):
         return self.api.bootstrap.liveviews[self.liveview_id]
 
     async def set_liveview(self, liveview: Liveview) -> None:
-        """Sets the liveview current set for the viewer"""
+        """
+        Sets the liveview current set for the viewer
+
+        Args:
+
+        * `liveview`: The liveview you want to set
+        """
 
         if self._api is not None:
             if liveview.id not in self._api.bootstrap.liveviews:

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -109,7 +109,9 @@ class Event(ProtectModelWithId):
     async def get_video(self, channel_index: int = 0) -> Optional[bytes]:
         """Get the MP4 video clip for this given event
 
-        :param channel_index: index of `CameraChannel` on the camera to use to retrieve video from
+        Args:
+
+        * `channel_index`: index of `CameraChannel` on the camera to use to retrieve video from
 
         Will raise an exception if event does not have a camera, end time or the channel index is wrong.
         """


### PR DESCRIPTION
Since we are not using Sphinx (and VS Codes not support Sphinx style docstrings), I have optimized all of the existing doc strings to work better in VS Code.

Before:
![image](https://user-images.githubusercontent.com/490848/140939639-517b55ba-c6dc-4c33-a874-afd3317fe992.png)

 
After:
![Code_4VVktZuB7I](https://user-images.githubusercontent.com/490848/140939536-a60fb830-f604-49c0-a3c2-7bcb22ef868c.png)
:
