### PR TITLE
Fixes typing error

### DIFF
--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -53,7 +53,6 @@ class ProtectBaseObject(BaseModel):
     _protect_objs: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
     _protect_lists: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
     _protect_dicts: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
-    _unifi_remaps: ClassVar[Optional[Dict[str, str]]] = None
 
     class Config:
         arbitrary_types_allowed = True


### PR DESCRIPTION
Some typing error started happening for python 3.9. This removes an unused attribute that is causing the issues.