### PR TITLE
Removes the dt argument for generating snapshots

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -769,13 +769,10 @@ class ProtectApiClient(BaseApiClient):
         camera_id: str,
         width: Optional[int] = None,
         height: Optional[int] = None,
-        dt: Optional[datetime] = None,
     ) -> Optional[bytes]:
-        """Gets a snapshot from a given camera at a given time"""
+        """Gets a snapshot from a camera"""
 
-        if dt is None:
-            dt = utc_now()
-
+        dt = utc_now()  # ts is only used as a cache buster
         params = {
             "ts": to_js_time(dt),
             "force": "true",

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -658,12 +658,10 @@ class Camera(ProtectMotionDeviceModel):
         if index is not None:
             self.privacy_zones.pop(index)
 
-    async def get_snapshot(
-        self, width: Optional[int] = None, height: Optional[int] = None, dt: Optional[datetime] = None
-    ) -> Optional[bytes]:
-        """Gets snapshot for camera at a given time"""
+    async def get_snapshot(self, width: Optional[int] = None, height: Optional[int] = None) -> Optional[bytes]:
+        """Gets snapshot for camera"""
 
-        return await self.api.get_camera_snapshot(self.id, width, height, dt)
+        return await self.api.get_camera_snapshot(self.id, width, height)
 
     async def get_video(self, start: datetime, end: datetime, channel_index: int = 0) -> Optional[bytes]:
         """Gets video clip for camera at a given time"""


### PR DESCRIPTION
* Removes the `dt` argument from `get_camera_snapshot` and `get_snapshot` as it does not function as expected. It looks like the `ts=` param  is _only_ used as a cache buster in UFP and does not actually function as a way to get a snapshot from a specific time.

I was never actually verifying that it worked quite as expected before. Just seeing it gave me an image.