### PR TITLE
Adds retrieving the Smart Detect Track for a smart detection

### DIFF
--- a/pyunifiprotect/data/__init__.py
+++ b/pyunifiprotect/data/__init__.py
@@ -16,6 +16,8 @@ from pyunifiprotect.data.nvr import (
     Group,
     Liveview,
     NVRLocation,
+    SmartDetectItem,
+    SmartDetectTrack,
     User,
     UserLocation,
 )
@@ -77,7 +79,9 @@ __all__ = [
     "ProtectWSPayloadFormat",
     "RecordingMode",
     "Sensor",
+    "SmartDetectItem",
     "SmartDetectObjectType",
+    "SmartDetectTrack",
     "StateType",
     "User",
     "UserLocation",

--- a/pyunifiprotect/test_util/anonymize.py
+++ b/pyunifiprotect/test_util/anonymize.py
@@ -72,7 +72,7 @@ def anonymize_value(value: Any, name: Optional[str] = None) -> Any:
             value = anonymize_peristent_string(value, random_hex(12).upper())
         elif name == "name" and value != "Default":
             value = f"{random_word()} {random_word()}".title()
-        elif name in ("owner", "user", "camera", "liveview", "authUserId"):
+        elif name in ("owner", "user", "camera", "liveview", "authUserId", "event"):
             value = anonymize_object_id(value)
         elif name == "rtsp":
             value = anonymize_rstp_url(value)
@@ -96,7 +96,7 @@ def anonymize_dict(obj: Dict[str, Any], name: Optional[str] = None) -> Dict[str,
 
     for key, value in obj.items():
         handled = False
-        if obj_type is not None:
+        if obj_type is not None or "payload" in obj:
             if key == "id":
                 obj[key] = anonymize_object_id(value)
                 handled = True

--- a/tests/sample_data/sample_event_smart_track.json
+++ b/tests/sample_data/sample_event_smart_track.json
@@ -1,0 +1,432 @@
+{
+    "id": "9157b87268305330a43d1916",
+    "payload": [
+        {
+            "id": "79",
+            "timestamp": 1637041411188,
+            "level": 83,
+            "coord": [
+                759,
+                388,
+                73,
+                294
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041411450,
+            "level": 83,
+            "coord": [
+                731,
+                355,
+                73,
+                288
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041411711,
+            "level": 87,
+            "coord": [
+                721,
+                325,
+                64,
+                280
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041411970,
+            "level": 83,
+            "coord": [
+                715,
+                297,
+                68,
+                275
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041412232,
+            "level": 78,
+            "coord": [
+                707,
+                275,
+                67,
+                275
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041412508,
+            "level": 84,
+            "coord": [
+                690,
+                249,
+                60,
+                263
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041412775,
+            "level": 82,
+            "coord": [
+                676,
+                233,
+                56,
+                249
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 257
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041413032,
+            "level": 67,
+            "coord": [
+                667,
+                219,
+                59,
+                241
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 257
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041413294,
+            "level": 42,
+            "coord": [
+                646,
+                208,
+                64,
+                241
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 257
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041413553,
+            "level": 62,
+            "coord": [
+                632,
+                191,
+                59,
+                230
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 257
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041413809,
+            "level": 50,
+            "coord": [
+                623,
+                183,
+                54,
+                219
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041414328,
+            "level": 66,
+            "coord": [
+                587,
+                163,
+                53,
+                205
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041414587,
+            "level": 30,
+            "coord": [
+                571,
+                152,
+                50,
+                197
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041414851,
+            "level": 51,
+            "coord": [
+                548,
+                155,
+                56,
+                191
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041415107,
+            "level": 73,
+            "coord": [
+                528,
+                147,
+                50,
+                188
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041415369,
+            "level": 67,
+            "coord": [
+                506,
+                158,
+                53,
+                186
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041415627,
+            "level": 59,
+            "coord": [
+                484,
+                163,
+                48,
+                180
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041415890,
+            "level": 44,
+            "coord": [
+                459,
+                169,
+                51,
+                180
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "79",
+            "timestamp": 1637041416147,
+            "level": 67,
+            "coord": [
+                442,
+                172,
+                46,
+                183
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "80",
+            "timestamp": 1637041417704,
+            "level": 60,
+            "coord": [
+                320,
+                208,
+                35,
+                147
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 255
+        },
+        {
+            "id": "80",
+            "timestamp": 1637041417967,
+            "level": 64,
+            "coord": [
+                300,
+                222,
+                39,
+                166
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 255
+        },
+        {
+            "id": "80",
+            "timestamp": 1637041418230,
+            "level": 65,
+            "coord": [
+                284,
+                222,
+                37,
+                169
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 255
+        },
+        {
+            "id": "80",
+            "timestamp": 1637041418501,
+            "level": 40,
+            "coord": [
+                271,
+                216,
+                46,
+                180
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 255
+        },
+        {
+            "id": "80",
+            "timestamp": 1637041418773,
+            "level": 55,
+            "coord": [
+                262,
+                213,
+                50,
+                186
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 256
+        },
+        {
+            "id": "80",
+            "timestamp": 1637041419344,
+            "level": 40,
+            "coord": [
+                253,
+                202,
+                54,
+                147
+            ],
+            "objectType": "person",
+            "zones": [
+                1
+            ],
+            "lines": [],
+            "duration": 259
+        }
+    ],
+    "camera": "8a0f3d0007784a7a6b0c334c",
+    "event": "d97d59c6d9f5b0a81f232755"
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -540,3 +540,16 @@ async def test_get_event_heatmap(protect_client: ProtectApiClient):
 
     img = Image.open(BytesIO(data))
     assert img.format in ("PNG", "JPEG")
+
+
+@pytest.mark.skipif(
+    not (SAMPLE_DATA_DIRECTORY / "sample_event_smart_track.json").exists(), reason="No smart track in testdata"
+)
+@pytest.mark.asyncio
+async def test_get_event_smart_detect_track(protect_client: ProtectApiClient):
+    data = await protect_client.get_event_smart_detect_track("test_id")
+    assert data.camera
+
+    protect_client.api_request.assert_called_with(  # type: ignore
+        url="events/test_id/smartDetectTrack", method="get", require_auth=True, raise_exception=True
+    )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -21,11 +21,7 @@ from pyunifiprotect.data import (
 )
 from pyunifiprotect.exceptions import BadRequest, StreamError
 from pyunifiprotect.utils import set_debug, set_no_debug
-from tests.conftest import (
-    SAMPLE_DATA_DIRECTORY,
-    MockTalkback,
-    compare_objs,
-)
+from tests.conftest import SAMPLE_DATA_DIRECTORY, MockTalkback, compare_objs
 
 PACKET_B64 = "AQEBAAAAAHR4nB2MQQrCMBBFr1JmbSDNpJnRG4hrDzBNZqCgqUiriHh3SZb/Pd7/guRtWSucBtgfRTaFwwBV39c+zqUJskQW1DufUVwkJsfFxDGLyRFj0dSz+1r0dtFPa+rr2dDSD8YsyceUpskQxzjjHIIQMvz+hMoj/AIBAQAAAAA1eJyrViotKMnMTVWyUjA0MjawMLQ0MDDQUVDKSSwuCU5NzQOJmxkbACUszE0sLQ1rAVU/DPU="
 PACKET_ACTION = {


### PR DESCRIPTION
Implements https://github.com/briis/pyunifiprotect/issues/98. Everything except the last point about creating the image. 
The `ts=` query param for `camera/{id}/snapshot` did not work like I expected. See https://github.com/briis/pyunifiprotect/pull/100. The only other way I can think to implement that is to splice frames out of the video using ffmpeg, but the exported videos are not 100% accurate, so it could result into bad images.

*  `ProtectApiClient`: Adds passing API reference for `get_device` methods
*  `ProtectApiClient`: Adds `get_event` method
*  `ProtectApiClient`: Adds `get_event_smart_detect_track_raw` / `get_event_smart_detect_track` methods
* `.data`: Adds `SmartDetectTrack` and `SmartDetectItem` classes
* `Event`: Adds `get_smart_detect_track` and `get_smart_detect_zones`
