### PR TITLE
Adds get_bootstrap and get_nvr methods

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -499,6 +499,8 @@ class ProtectApiClient(BaseApiClient):
         """
         Updates the state of devices, initalizes `.bootstrap` and
         connects to UFP Websocket for real time updates
+
+        You can use the various other `get_` methods if you need one off data from UFP
         """
 
         now = time.monotonic()

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -17,6 +17,7 @@ import jwt
 from yarl import URL
 
 from pyunifiprotect.data import (
+    NVR,
     Bootstrap,
     Bridge,
     Camera,
@@ -509,8 +510,7 @@ class ProtectApiClient(BaseApiClient):
 
         if self._bootstrap is None or now - self._last_update > DEVICE_UPDATE_INTERVAL:
             self._last_update = now
-            data = await self.api_request_obj("bootstrap")
-            self._bootstrap = Bootstrap.from_unifi_dict(**data, api=self)
+            self._bootstrap = await self.get_bootstrap()
 
         active_ws = await self.check_ws()
         # If the websocket is connected/connecting
@@ -634,6 +634,16 @@ class ProtectApiClient(BaseApiClient):
         self._ws_subscriptions.append(ws_callback)
         return _unsub_ws_callback
 
+    async def get_bootstrap(self) -> Bootstrap:
+        """
+        Gets bootstrap object from UFP instance
+
+        This is a great alternative if you need metadata about the NVR without connecting to the Websocket
+        """
+
+        data = await self.api_request_obj("bootstrap")
+        return Bootstrap.from_unifi_dict(**data, api=self)
+
     async def get_devices_raw(self, model_type: ModelType) -> List[Dict[str, Any]]:
         """Gets a raw device list given a model_type"""
         return await self.api_request_list(f"{model_type.value}s")
@@ -716,6 +726,16 @@ class ProtectApiClient(BaseApiClient):
             raise NvrError(f"Unexpected model returned: {obj.model}")
 
         return obj
+
+    async def get_nvr(self) -> NVR:
+        """
+        Gets an NVR object straight from the NVR.
+
+        This is a great alternative if you need metadata about the NVR without connecting to the Websocket
+        """
+
+        data = await self.api_request_obj("nvr")
+        return NVR.from_unifi_dict(**data, api=self)
 
     async def get_event(self, event_id: str) -> Event:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,8 @@ async def mock_api_request_raw(url: str, *args, **kwargs):
 async def mock_api_request(url: str, *args, **kwargs):
     if url == "bootstrap":
         return read_json_file("sample_bootstrap")
+    elif url == "nvr":
+        return read_json_file("sample_bootstrap")["nvr"]
     elif url == "events":
         return read_json_file("sample_raw_events")
     elif url == "cameras":
@@ -320,6 +322,11 @@ def raw_events():
 @pytest.fixture
 def bootstrap():
     return read_json_file("sample_bootstrap")
+
+
+@pytest.fixture
+def nvr():
+    return read_json_file("sample_bootstrap")["nvr"]
 
 
 @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -157,6 +157,22 @@ async def test_force_update(protect_client: ProtectApiClient):
 
 
 @pytest.mark.asyncio
+async def test_get_nvr(protect_client: ProtectApiClient, nvr):
+    """Verifies the `get_nvr` method"""
+
+    # TODO:
+    del nvr["uiVersion"]
+    del nvr["errorCode"]
+    del nvr["wifiSettings"]
+    del nvr["smartDetectAgreement"]
+    del nvr["ssoChannel"]
+    del nvr["doorbellSettings"]["customMessages"]
+
+    nvr_obj = await protect_client.get_nvr()
+    assert nvr_obj.unifi_dict() == nvr
+
+
+@pytest.mark.asyncio
 async def test_bootstrap(protect_client: ProtectApiClient):
     """Verifies lookup of all object via ID"""
 


### PR DESCRIPTION
Based on some WIP changes I saw @briis doing. Added some extra methods to grab data without connecting to Websocket.


* `ProtectApiClient`: Adds `get_nvr`
* `ProtectApiClient`: Adds `get_bootstrap`
