### PR TITLE
Requires no HDR to set WDR

### DIFF
--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -761,6 +761,10 @@ class Camera(ProtectMotionDeviceModel):
 
     async def set_wdr_level(self, level: WDRLevel) -> None:
         """Sets WDR (Wide Dynamic Range) on camera"""
+
+        if self.feature_flags.has_hdr:
+            raise BadRequest("Cannot set WDR on cameras with HDR")
+
         self.isp_settings.wdr = level
         await self.save_device()
 

--- a/tests/test_data_updates.py
+++ b/tests/test_data_updates.py
@@ -394,6 +394,7 @@ async def test_camera_set_wdr_level(camera_obj: Optional[Camera], level: int):
 
     camera_obj.api.api_request.reset_mock()
 
+    camera_obj.feature_flags.has_hdr = False
     camera_obj.isp_settings.wdr = 2
     camera_obj._initial_data = camera_obj.dict()
 
@@ -410,6 +411,22 @@ async def test_camera_set_wdr_level(camera_obj: Optional[Camera], level: int):
             method="patch",
             json={"ispSettings": {"wdr": level}},
         )
+
+
+@pytest.mark.asyncio
+async def test_camera_set_wdr_level_hdr(camera_obj: Optional[Camera]):
+    if camera_obj is None:
+        pytest.skip("No camera_obj obj found")
+
+    camera_obj.api.api_request.reset_mock()
+
+    camera_obj.feature_flags.has_hdr = True
+    camera_obj._initial_data = camera_obj.dict()
+
+    with pytest.raises(BadRequest):
+        await camera_obj.set_wdr_level(1)
+
+    assert not camera_obj.api.api_request.called
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I am kind of torn on this one. I _think_ this is a new change in Protect that does not expose changing WDR when the camera has HDR. I have 1x G4 Bullet (HDR), 4x G4 Pros (HDR), and 1x G4 Doorbell (no HDR) and WDR _only_ appears on my G4 Doorbell now, in the Protect WebUI.

I remember changing the WDR for my G4 Pros previously, but it seems to have changed. It looks like changing WDR on an HDR camera does still have some effect (I see the lens do something, but the picture quality does not really change). So we may not want to enforce this, but if we want to stay inline with how Protect works...