### PR TITLE
Adds option to force emit messages when an object is changed

### DIFF
--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -18,7 +18,12 @@ from typing import (
 from pydantic import BaseModel
 from pydantic.fields import SHAPE_DICT, SHAPE_LIST, PrivateAttr
 
-from pyunifiprotect.data.types import ModelType, StateType
+from pyunifiprotect.data.types import ModelType, ProtectWSPayloadFormat, StateType
+from pyunifiprotect.data.websocket import (
+    WSJSONPacketFrame,
+    WSPacket,
+    WSPacketFrameHeader,
+)
 from pyunifiprotect.exceptions import BadRequest
 from pyunifiprotect.utils import (
     convert_unifi_data,
@@ -564,7 +569,7 @@ class ProtectAdoptableDeviceModel(ProtectDeviceModel):
 
         return updated
 
-    async def save_device(self) -> None:
+    async def save_device(self, force_emit: bool = False) -> None:
         """
         Generates a diff for unsaved changed on the device and sends them back to UFP
 
@@ -572,6 +577,10 @@ class ProtectAdoptableDeviceModel(ProtectDeviceModel):
         May have unexpected side effects.
 
         Tested updates have been added a methods on applicable devices.
+
+        Args:
+
+        * `force_emit`: Emit a fake UFP WS message. Should only be use for when UFP does not properly emit a WS message
         """
 
         if self.model is None:
@@ -586,6 +595,23 @@ class ProtectAdoptableDeviceModel(ProtectDeviceModel):
 
         await self.api.update_device(self.model, self.id, updated)
         self._initial_data = new_data
+
+        if force_emit:
+            header = WSPacketFrameHeader(
+                packet_type=1, payload_format=ProtectWSPayloadFormat.JSON.value, deflated=0, unknown=1, payload_size=1
+            )
+
+            action_frame = WSJSONPacketFrame()
+            action_frame.header = header
+            action_frame.data = {"action": "update", "newUpdateId": None, "modelKey": self.model.value, "id": self.id}
+
+            data_frame = WSJSONPacketFrame()
+            data_frame.header = header
+            data_frame.data = updated
+
+            message = self.api.bootstrap.process_ws_packet(WSPacket(action_frame.packed + data_frame.packed))
+            if message is not None:
+                self.api.emit_message(message)
 
 
 class ProtectMotionDeviceModel(ProtectAdoptableDeviceModel):

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -596,22 +596,24 @@ class ProtectAdoptableDeviceModel(ProtectDeviceModel):
         await self.api.update_device(self.model, self.id, updated)
         self._initial_data = new_data
 
-        if force_emit:
-            header = WSPacketFrameHeader(
-                packet_type=1, payload_format=ProtectWSPayloadFormat.JSON.value, deflated=0, unknown=1, payload_size=1
-            )
+        if not force_emit:
+            return
 
-            action_frame = WSJSONPacketFrame()
-            action_frame.header = header
-            action_frame.data = {"action": "update", "newUpdateId": None, "modelKey": self.model.value, "id": self.id}
+        header = WSPacketFrameHeader(
+            packet_type=1, payload_format=ProtectWSPayloadFormat.JSON.value, deflated=0, unknown=1, payload_size=1
+        )
 
-            data_frame = WSJSONPacketFrame()
-            data_frame.header = header
-            data_frame.data = updated
+        action_frame = WSJSONPacketFrame()
+        action_frame.header = header
+        action_frame.data = {"action": "update", "newUpdateId": None, "modelKey": self.model.value, "id": self.id}
 
-            message = self.api.bootstrap.process_ws_packet(WSPacket(action_frame.packed + data_frame.packed))
-            if message is not None:
-                self.api.emit_message(message)
+        data_frame = WSJSONPacketFrame()
+        data_frame.header = header
+        data_frame.data = updated
+
+        message = self.api.bootstrap.process_ws_packet(WSPacket(action_frame.packed + data_frame.packed))
+        if message is not None:
+            self.api.emit_message(message)
 
 
 class ProtectMotionDeviceModel(ProtectAdoptableDeviceModel):

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 import logging
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, Optional, Set, Tuple
 from uuid import UUID
 
 from pyunifiprotect.data.base import ProtectBaseObject, ProtectModel, ProtectModelWithId
@@ -22,6 +22,12 @@ _LOGGER = logging.getLogger(__name__)
 
 MAX_SUPPORTED_CAMERAS = 256
 MAX_EVENT_HISTORY_IN_STATE_MACHINE = MAX_SUPPORTED_CAMERAS * 2
+
+EVENT_ATTR_MAP: Dict[EventType, Tuple[str, str]] = {
+    EventType.MOTION: ("last_motion", "last_motion_event_id"),
+    EventType.SMART_DETECT: ("last_smart_detect", "last_smart_detect_event_id"),
+    EventType.RING: ("last_ring", "last_ring_event_id"),
+}
 
 
 class Bootstrap(ProtectBaseObject):
@@ -81,25 +87,11 @@ class Bootstrap(ProtectBaseObject):
         if event.camera is None:
             return
 
-        if event.type == EventType.MOTION and (
-            event.camera.last_motion is None or event.start > event.camera.last_motion
-        ):
-            if event.end is None:
-                event.camera.is_motion_detected = True
-            else:
-                event.camera.is_motion_detected = False
-
-                event.camera.last_motion = event.end
-                event.camera.last_motion_event_id = event.id
-        elif event.type == EventType.SMART_DETECT and (
-            event.camera.last_smart_detect is None or event.start > event.camera.last_smart_detect
-        ):
-            if event.end is not None:
-                event.camera.last_smart_detect = event.end
-                event.camera.last_smart_detect_event_id = event.id
-        elif event.type == EventType.RING and (event.camera.last_ring is None or event.start > event.camera.last_ring):
-            event.camera.last_ring = event.start
-            event.camera.last_ring_event_id = event.id
+        if event.type in EVENT_ATTR_MAP:
+            dt_attr, event_attr = EVENT_ATTR_MAP[event.type]
+            dt = getattr(event.camera, dt_attr)
+            if dt is None or event.start >= dt or event.end >= dt:
+                setattr(event.camera, event_attr, event.id)
 
         self.events[event.id] = event
 

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -90,7 +90,7 @@ class Bootstrap(ProtectBaseObject):
         if event.type in EVENT_ATTR_MAP:
             dt_attr, event_attr = EVENT_ATTR_MAP[event.type]
             dt = getattr(event.camera, dt_attr)
-            if dt is None or event.start >= dt or event.end >= dt:
+            if dt is None or event.start >= dt or (event.end is not None and event.end >= dt):
                 setattr(event.camera, event_attr, event.id)
 
         self.events[event.id] = event

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -112,7 +112,8 @@ class Bootstrap(ProtectBaseObject):
 
         action: dict = packet.action_frame.data  # type: ignore
         data: dict = packet.data_frame.data  # type: ignore
-        self.last_update_id = UUID(action["newUpdateId"])
+        if action["newUpdateId"] is not None:
+            self.last_update_id = UUID(action["newUpdateId"])
 
         if action["modelKey"] not in ModelType.values():
             _LOGGER.debug("Unknown model type: %s", action["modelKey"])

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -118,6 +118,12 @@ class Light(ProtectMotionDeviceModel):
 
         await self.save_device()
 
+    async def set_sensitivity(self, sensitivity: PercentInt) -> None:
+        """Sets motion sensitivity"""
+
+        self.light_device_settings.pir_sensitivity = sensitivity
+        await self.save_device()
+
     async def set_light_settings(
         self,
         mode: LightModeType,

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -350,6 +350,8 @@ class LCDMessage(ProtectBaseObject):
             data["text"] = self._fix_text(data["text"], data.get("type", self.type.value))
         if "resetAt" in data:
             data["resetAt"] = to_js_time(data["resetAt"])
+        else:
+            data["resetAt"] = None
 
         return data
 
@@ -916,7 +918,8 @@ class Viewer(ProtectAdoptableDeviceModel):
                 raise BadRequest("Unknown liveview")
 
         self.liveview_id = liveview.id
-        await self.save_device()
+        # UniFi Protect bug: changing the liveview does _not_ emit a WS message
+        await self.save_device(force_emit=True)
 
 
 class Bridge(ProtectAdoptableDeviceModel):

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -671,16 +671,21 @@ class Camera(ProtectMotionDeviceModel):
     def get_changed(self) -> Dict[str, Any]:
         updated = super().get_changed()
 
-        # if reset_at is not passed in, it will default to reset in 1 minute
-        lcd_message = updated.get("lcd_message")
-        if lcd_message is not None and "reset_at" not in lcd_message:
-            if self.lcd_message is None:
-                updated["lcd_message"]["reset_at"] = None
-            else:
-                updated["lcd_message"]["reset_at"] = self.lcd_message.reset_at
-        # to "clear" LCD message, set reset_at to a time in the past
-        elif "lcd_message" in updated and lcd_message is None:
-            updated["lcd_message"] = {"reset_at": utc_now() - timedelta(seconds=10)}
+        if "lcd_message" in updated:
+            lcd_message = updated["lcd_message"]
+            # to "clear" LCD message, set reset_at to a time in the past
+            if lcd_message is None:
+                updated["lcd_message"] = {"reset_at": utc_now() - timedelta(seconds=10)}
+            # otherwise, pass full LCD message to prevent issues
+            elif self.lcd_message is not None:
+                updated["lcd_message"] = self.lcd_message.dict()
+
+            # if reset_at is not passed in, it will default to reset in 1 minute
+            if lcd_message is not None and "reset_at" not in lcd_message:
+                if self.lcd_message is None:
+                    updated["lcd_message"]["reset_at"] = None
+                else:
+                    updated["lcd_message"]["reset_at"] = self.lcd_message.reset_at
 
         return updated
 

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -124,6 +124,15 @@ class Light(ProtectMotionDeviceModel):
         self.light_device_settings.pir_sensitivity = sensitivity
         await self.save_device()
 
+    async def set_duration(self, duration: timedelta) -> None:
+        """Sets motion sensitivity"""
+
+        if duration.total_seconds() < 15 or duration.total_seconds() > 900:
+            raise BadRequest("Duration outside of 15s to 900s range")
+
+        self.light_device_settings.pir_duration = duration
+        await self.save_device()
+
     async def set_light_settings(
         self,
         mode: LightModeType,

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -114,6 +114,7 @@ class EventType(str, ValuesEnumMixin, enum.Enum):
 @enum.unique
 class StateType(str, enum.Enum):
     CONNECTED = "CONNECTED"
+    CONNECTING = "CONNECTING"
     DISCONNECTED = "DISCONNECTED"
 
 

--- a/pyunifiprotect/data/websocket.py
+++ b/pyunifiprotect/data/websocket.py
@@ -6,13 +6,15 @@ from dataclasses import dataclass
 import enum
 import json
 import struct
-from typing import Any, Dict, Optional, Type
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 from uuid import UUID
 import zlib
 
-from pyunifiprotect.data.base import ProtectModel
 from pyunifiprotect.data.types import ProtectWSPayloadFormat
 from pyunifiprotect.exceptions import WSDecodeError, WSEncodeError
+
+if TYPE_CHECKING:
+    from pyunifiprotect.data.base import ProtectModel
 
 WS_HEADER_SIZE = 8
 

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -244,8 +244,11 @@ def ip_from_host(host: str) -> IPv4Address:
     return IPv4Address(socket.gethostbyname(host))
 
 
-def dict_diff(orig: Dict[str, Any], new: Dict[str, Any]) -> Dict[str, Any]:
+def dict_diff(orig: Optional[Dict[str, Any]], new: Dict[str, Any]) -> Dict[str, Any]:
     changed: Dict[str, Any] = {}
+
+    if orig is None:
+        return new
 
     for key, value in new.items():
         if key not in orig:

--- a/tests/test_api_polling.py
+++ b/tests/test_api_polling.py
@@ -65,14 +65,6 @@ async def test_process_events_ring(protect_client: ProtectApiClient, now, camera
 
     await protect_client.update()
 
-    camera_index = -1
-    for index, camera_dict in enumerate(bootstrap_before["cameras"]):
-        if camera_dict["id"] == camera["id"]:
-            camera_index = index
-            break
-
-    camera_before.last_ring = now - timedelta(seconds=1)
-    bootstrap_before["cameras"][camera_index]["lastRing"] = to_js_time(camera_before.last_ring)
     bootstrap = protect_client.bootstrap.unifi_dict()
     camera = get_camera()
 
@@ -86,57 +78,6 @@ async def test_process_events_ring(protect_client: ProtectApiClient, now, camera
     assert event.type == EventType.RING
     assert event.thumbnail_id == f"e-{expected_event_id}"
     assert event.heatmap_id == f"e-{expected_event_id}"
-    assert event.start == camera.last_ring
-
-
-@pytest.mark.asyncio
-@patch("pyunifiprotect.api.datetime", MockDatetime)
-async def test_process_events_motion_in_progress(protect_client: ProtectApiClient, now, camera):
-    def get_camera():
-        return protect_client.bootstrap.cameras[camera["id"]]
-
-    bootstrap_before = protect_client.bootstrap.unifi_dict()
-    camera_before = get_camera().copy()
-
-    expected_event_id = "bf9a241afe74821ceffffd05"
-
-    async def get_events(*args, **kwargs):
-        return [
-            {
-                "id": expected_event_id,
-                "type": "motion",
-                "start": to_js_time(now),
-                "end": None,
-                "score": 0,
-                "smartDetectTypes": [],
-                "smartDetectEvents": [],
-                "camera": camera["id"],
-                "partition": None,
-                "user": None,
-                "metadata": {},
-                "thumbnail": f"e-{expected_event_id}",
-                "heatmap": f"e-{expected_event_id}",
-                "modelKey": "event",
-            },
-        ]
-
-    setattr(protect_client, "get_events_raw", get_events)
-
-    await protect_client.update()
-
-    camera_index = -1
-    for index, camera_dict in enumerate(bootstrap_before["cameras"]):
-        if camera_dict["id"] == camera["id"]:
-            camera_index = index
-            break
-
-    camera_before.is_motion_detected = True
-    bootstrap_before["cameras"][camera_index]["isMotionDetected"] = True
-    bootstrap = protect_client.bootstrap.unifi_dict()
-    camera = get_camera()
-
-    assert bootstrap == bootstrap_before
-    assert camera == camera_before
 
 
 @pytest.mark.asyncio
@@ -174,16 +115,7 @@ async def test_process_events_motion(protect_client: ProtectApiClient, now, came
 
     await protect_client.update()
 
-    camera_index = -1
-    for index, camera_dict in enumerate(bootstrap_before["cameras"]):
-        if camera_dict["id"] == camera["id"]:
-            camera_index = index
-            break
-
-    camera_before.last_motion = now
     camera_before.is_motion_detected = False
-    bootstrap_before["cameras"][camera_index]["lastMotion"] = to_js_time(camera_before.last_motion)
-    bootstrap_before["cameras"][camera_index]["isMotionDetected"] = False
     bootstrap = protect_client.bootstrap.unifi_dict()
     camera = get_camera()
 
@@ -198,7 +130,6 @@ async def test_process_events_motion(protect_client: ProtectApiClient, now, came
     assert event.thumbnail_id == f"e-{expected_event_id}"
     assert event.heatmap_id == f"e-{expected_event_id}"
     assert event.start == (now - timedelta(seconds=30))
-    assert event.end == camera.last_motion
 
 
 @pytest.mark.asyncio
@@ -236,14 +167,6 @@ async def test_process_events_smart(protect_client: ProtectApiClient, now, camer
 
     await protect_client.update()
 
-    camera_index = -1
-    for index, camera_dict in enumerate(bootstrap_before["cameras"]):
-        if camera_dict["id"] == camera["id"]:
-            camera_index = index
-            break
-
-    camera_before.last_smart_detect = now
-    bootstrap_before["cameras"][camera_index]["lastMotion"] = to_js_time(camera_before.last_motion)
     bootstrap = protect_client.bootstrap.unifi_dict()
     camera = get_camera()
 

--- a/tests/test_data_updates.py
+++ b/tests/test_data_updates.py
@@ -106,6 +106,34 @@ async def test_light_set_light(light_obj: Light, status: bool, level: Optional[i
         )
 
 
+@pytest.mark.parametrize("sensitivity", [1, 100, -10])
+@pytest.mark.asyncio
+async def test_light_set_sensitivity(
+    light_obj: Light,
+    sensitivity: int,
+):
+    light_obj.api.api_request.reset_mock()
+
+    light_obj.light_device_settings.pir_sensitivity = 50
+    light_obj._initial_data = light_obj.dict()
+
+    if sensitivity == -10:
+        with pytest.raises(ValidationError):
+            await light_obj.set_sensitivity(sensitivity)
+
+            assert not light_obj.api.api_request.called
+    else:
+        await light_obj.set_sensitivity(sensitivity)
+
+        expected = {"lightDeviceSettings": {"pirSensitivity": sensitivity}}
+
+        light_obj.api.api_request.assert_called_with(
+            f"lights/{light_obj.id}",
+            method="patch",
+            json=expected,
+        )
+
+
 @pytest.mark.parametrize("mode", [LightModeType.MANUAL, LightModeType.WHEN_DARK])
 @pytest.mark.parametrize("enable_at", [None, LightModeEnableType.ALWAYS])
 @pytest.mark.parametrize(

--- a/tests/test_data_updates.py
+++ b/tests/test_data_updates.py
@@ -609,8 +609,6 @@ async def test_camera_set_lcd_text_custom(camera_obj: Optional[Camera]):
         method="patch",
         json={
             "lcdMessage": {
-                "type": DoorbellMessageType.CUSTOM_MESSAGE.value,
-                "text": "Test",
                 "resetAt": to_js_time(now),
             }
         },
@@ -657,6 +655,37 @@ async def test_camera_set_lcd_text(camera_obj: Optional[Camera]):
             "lcdMessage": {
                 "type": DoorbellMessageType.LEAVE_PACKAGE_AT_DOOR.value,
                 "text": DoorbellMessageType.LEAVE_PACKAGE_AT_DOOR.value.replace("_", " "),
+                "resetAt": None,
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_camera_set_lcd_text_none(camera_obj: Optional[Camera]):
+    if camera_obj is None:
+        pytest.skip("No camera_obj obj found")
+
+    camera_obj.api.api_request.reset_mock()
+
+    camera_obj.feature_flags.has_lcd_screen = True
+    camera_obj.lcd_message = LCDMessage(
+        type=DoorbellMessageType.DO_NOT_DISTURB,
+        text=DoorbellMessageType.DO_NOT_DISTURB.value.replace("_", " "),
+        reset_at=None,
+    )
+    camera_obj._initial_data = camera_obj.dict()
+
+    await camera_obj.set_lcd_text(None)
+
+    camera_obj.api.api_request.assert_called_with(
+        f"cameras/{camera_obj.id}",
+        method="patch",
+        json={
+            "lcdMessage": {
+                "type": DoorbellMessageType.LEAVE_PACKAGE_AT_DOOR.value,
+                "text": DoorbellMessageType.LEAVE_PACKAGE_AT_DOOR.value.replace("_", " "),
+                "resetAt": camera_obj.lcd_message.reset_at,
             }
         },
     )

--- a/tests/test_data_updates.py
+++ b/tests/test_data_updates.py
@@ -618,6 +618,35 @@ async def test_camera_set_lcd_text_custom(camera_obj: Optional[Camera]):
 
 
 @pytest.mark.asyncio
+async def test_camera_set_lcd_text_custom_to_custom(camera_obj: Optional[Camera]):
+
+    camera_obj.api.api_request.reset_mock()
+
+    camera_obj.feature_flags.has_lcd_screen = True
+    camera_obj.lcd_message = LCDMessage(
+        type=DoorbellMessageType.CUSTOM_MESSAGE,
+        text="Welcome",
+        reset_at=None,
+    )
+    camera_obj._initial_data = camera_obj.dict()
+
+    now = datetime.utcnow()
+    await camera_obj.set_lcd_text(DoorbellMessageType.CUSTOM_MESSAGE, "Test", now)
+
+    camera_obj.api.api_request.assert_called_with(
+        f"cameras/{camera_obj.id}",
+        method="patch",
+        json={
+            "lcdMessage": {
+                "type": DoorbellMessageType.CUSTOM_MESSAGE.value,
+                "text": "Test",
+                "resetAt": to_js_time(now),
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
 async def test_camera_set_lcd_text_invalid_text(camera_obj: Optional[Camera]):
     if camera_obj is None:
         pytest.skip("No camera_obj obj found")

--- a/tests/test_data_updates.py
+++ b/tests/test_data_updates.py
@@ -3,7 +3,7 @@
 
 from datetime import datetime, timedelta
 from typing import Optional
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from pydantic.error_wrappers import ValidationError
 import pytest
@@ -609,6 +609,8 @@ async def test_camera_set_lcd_text_custom(camera_obj: Optional[Camera]):
         method="patch",
         json={
             "lcdMessage": {
+                "type": DoorbellMessageType.CUSTOM_MESSAGE.value,
+                "text": "Test",
                 "resetAt": to_js_time(now),
             }
         },
@@ -662,7 +664,10 @@ async def test_camera_set_lcd_text(camera_obj: Optional[Camera]):
 
 
 @pytest.mark.asyncio
-async def test_camera_set_lcd_text_none(camera_obj: Optional[Camera]):
+@patch("pyunifiprotect.data.devices.utc_now")
+async def test_camera_set_lcd_text_none(mock_now, camera_obj: Optional[Camera], now: datetime):
+    mock_now.return_value = now
+
     if camera_obj is None:
         pytest.skip("No camera_obj obj found")
 
@@ -683,9 +688,7 @@ async def test_camera_set_lcd_text_none(camera_obj: Optional[Camera]):
         method="patch",
         json={
             "lcdMessage": {
-                "type": DoorbellMessageType.LEAVE_PACKAGE_AT_DOOR.value,
-                "text": DoorbellMessageType.LEAVE_PACKAGE_AT_DOOR.value.replace("_", " "),
-                "resetAt": camera_obj.lcd_message.reset_at,
+                "resetAt": to_js_time(now - timedelta(seconds=10)),
             }
         },
     )


### PR DESCRIPTION
* Adds option to force emit messages when an object is changed
* Ensures PATCH requests for updating an LCDMessage object is always what UFP is expecting:
   * If no `resetAt` was passed in, it was defaulted to +1 minute
   * If no `type` was passed in (for CUSTOM_MESSAGE -> CUSTOM_MESSAGE changes), the display would break

This one is to "fix" a bug in UFP. When you update a Viewer, it does not emit a WS message like updating other objects do. This will let you to pass `force_emit=True` on `save_device` to construct a fake WS message of the change.

This will allow downstream subscribers (like Home Assistant) to trigger updates properly in the absence of a real UFP message.

Other bundled changes/fixes for HA integration:
* `ProtectApiClient`: Ensure `start` param passed into `get_events` inside of `update` is always set
* `Bootstrap`: Simplifies event processing and only captures the reference to the latest event IDs instead of trying to update the object. Other WS messages will do that.
* Adds `set_sensitivity` and `set_duration` helper methods for lights