### PR TITLE
Fixes from testing

### DIFF
--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -966,8 +966,9 @@ class Viewer(ProtectAdoptableDeviceModel):
         return {**super()._get_unifi_remaps(), "liveview": "liveviewId"}
 
     @property
-    def liveview(self) -> Liveview:
-        return self.api.bootstrap.liveviews[self.liveview_id]
+    def liveview(self) -> Optional[Liveview]:
+        # user may not have permission to see the liveview
+        return self.api.bootstrap.liveviews.get(self.liveview_id)
 
     async def set_liveview(self, liveview: Liveview) -> None:
         """

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -493,7 +493,7 @@ class NVR(ProtectDeviceModel):
     def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "lastUpdateAt" in data:
             data["lastUpdateAt"] = process_datetime(data, "lastUpdateAt")
-        if "recordingRetentionDurationMs" in data and data["recordingRetentionDuration"] is not None:
+        if "recordingRetentionDurationMs" in data and data["recordingRetentionDurationMs"] is not None:
             data["recordingRetentionDuration"] = timedelta(milliseconds=data.pop("recordingRetentionDurationMs"))
         if "timezone" in data and not isinstance(data["timezone"], tzinfo):
             data["timezone"] = pytz.timezone(data["timezone"])
@@ -582,7 +582,8 @@ class LiveviewSlot(ProtectBaseObject):
         if self._cameras is not None:
             return self._cameras
 
-        self._cameras = [self.api.bootstrap.cameras[g] for g in self.camera_ids]
+        # user may not have permission to see the cameras in the liveview
+        self._cameras = [self.api.bootstrap.cameras[g] for g in self.camera_ids if g in self.api.bootstrap.cameras]
         return self._cameras
 
 

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -456,7 +456,7 @@ class NVR(ProtectDeviceModel):
     is_wireless_uplink_enabled: bool
     time_format: Literal["12h", "24h"]
     temperature_unit: Literal["C", "F"]
-    recording_retention_duration: timedelta
+    recording_retention_duration: Optional[timedelta]
     enable_crash_reporting: bool
     disable_audio: bool
     analytics_data: str
@@ -493,14 +493,12 @@ class NVR(ProtectDeviceModel):
     def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "lastUpdateAt" in data:
             data["lastUpdateAt"] = process_datetime(data, "lastUpdateAt")
-        if "recordingRetentionDurationMs" in data:
+        if "recordingRetentionDurationMs" in data and data["recordingRetentionDuration"] is not None:
             data["recordingRetentionDuration"] = timedelta(milliseconds=data.pop("recordingRetentionDurationMs"))
         if "timezone" in data and not isinstance(data["timezone"], tzinfo):
             data["timezone"] = pytz.timezone(data["timezone"])
 
-        data = super().unifi_dict_to_dict(data)
-
-        return data
+        return super().unifi_dict_to_dict(data)
 
     async def _api_update(self, data: Dict[str, Any]) -> None:
         return await self.api.update_nvr(data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -111,7 +111,8 @@ async def check_bootstrap(bootstrap: Bootstrap):
         assert liveview.protect_url == f"https://127.0.0.1:0/protect/liveview/{liveview.id}"
 
         for slot in liveview.slots:
-            assert len(slot.camera_ids) == len(slot.cameras)
+            expected_ids = set(slot.camera_ids).intersection(set(bootstrap.cameras.keys()))
+            assert len(expected_ids) == len(slot.cameras)
 
     for user in bootstrap.users.values():
         user.groups

--- a/tests/test_data_updates.py
+++ b/tests/test_data_updates.py
@@ -261,8 +261,6 @@ async def test_viewer_set_liveview_valid(viewer_obj: Viewer, liveview_obj: Livev
     viewer_obj.api.api_request.reset_mock()
     viewer_obj.api.emit_message = Mock()
 
-    old_viewer = viewer_obj.copy()
-
     viewer_obj.liveview_id = "bad_id"
     viewer_obj._initial_data = viewer_obj.dict()
 
@@ -273,12 +271,14 @@ async def test_viewer_set_liveview_valid(viewer_obj: Viewer, liveview_obj: Livev
         json={"liveview": liveview_obj.id},
     )
 
+    # old/new is actually the same here since the client
+    # generating the message is the one that changed it
     viewer_obj.api.emit_message.assert_called_with(
         WSSubscriptionMessage(
             action=WSAction.UPDATE,
             new_update_id=viewer_obj.api.bootstrap.last_update_id,
             changed_data={"liveview_id": liveview_obj.id},
-            old_obj=old_viewer,
+            old_obj=viewer_obj,
             new_obj=viewer_obj,
         )
     )
@@ -798,7 +798,6 @@ async def test_camera_set_lcd_text_none(mock_now, camera_obj: Optional[Camera], 
     if camera_obj is None:
         pytest.skip("No camera_obj obj found")
 
-    old_camera = camera_obj.copy()
     camera_obj.api.emit_message = Mock()
     camera_obj.api.api_request.reset_mock()
 
@@ -823,12 +822,14 @@ async def test_camera_set_lcd_text_none(mock_now, camera_obj: Optional[Camera], 
         },
     )
 
+    # old/new is actually the same here since the client
+    # generating the message is the one that changed it
     camera_obj.api.emit_message.assert_called_with(
         WSSubscriptionMessage(
             action=WSAction.UPDATE,
             new_update_id=camera_obj.api.bootstrap.last_update_id,
             changed_data={"lcd_message": {"reset_at": expected_dt}},
-            old_obj=old_camera,
+            old_obj=camera_obj,
             new_obj=camera_obj,
         )
     )


### PR DESCRIPTION
* Fixes `emit_message` for tests
* Making recording retention optional for NVRs that do not have any recording retention
* Fixes liveview/camera lookups for Viewports / Liveviews in the event user does not have permissions to see something