### PR TITLE
Optmizations for `ProtectApiClient`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye
+FROM python:3.10-slim-bullseye
 
 RUN apt-get update \
     && apt-get install -y git build-essential vim procps curl jq ffmpeg \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.9-slim-bullseye
 
 RUN apt-get update \
     && apt-get install -y git build-essential vim procps curl jq ffmpeg \

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -7,7 +7,18 @@ from ipaddress import IPv4Address
 import json as pjson
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Type, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Type,
+    Union,
+    cast,
+)
 from urllib.parse import urljoin
 from uuid import UUID
 
@@ -549,7 +560,7 @@ class ProtectApiClient(BaseApiClient):
             # If the websocket is connected/connecting
             # we do not need to get events
             _LOGGER.debug("Skipping update since websocket is active")
-            return
+            return None
 
         events = await self.get_events(start=self._last_update_dt or max_event_dt, end=now_dt)
         for event in events:

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -7,7 +7,7 @@ from ipaddress import IPv4Address
 import json as pjson
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Type, Union, cast
 from urllib.parse import urljoin
 from uuid import UUID
 
@@ -45,7 +45,7 @@ from pyunifiprotect.utils import (
 
 NEVER_RAN = -1000
 # how many seconds before the bootstrap is refreshed from Protect
-DEVICE_UPDATE_INTERVAL = 60
+DEVICE_UPDATE_INTERVAL = 900
 # how many seconds before before we check for an active WS connection
 WEBSOCKET_CHECK_INTERVAL = 120
 
@@ -446,9 +446,23 @@ class ProtectApiClient(BaseApiClient):
     All objects inside of `.bootstrap` have a refernce back to the API client so they can
     use `.save_device()` and update themselves using their own `.set_` methods on the object.
 
+    Args:
+
+    * `host`: UFP hostname / IP address
+    * `port`: UFP HTTPS port
+    * `username`: UFP username
+    * `password`: UFP password
+    * `verify_ssl`: Verify HTTPS certificate (default: `True`)
+    * `session`: Optional aiohttp session to use (default: generate one)
+    * `minimum_score`: minimum score for events (default: `0`)
+    * `subscribed_models`: Model types you want to filter events for WS. You will need to manually check the bootstrap for updates for events that not subscibred.
+    * `ignore_stats`: Ignore storage, system, etc. stats/metrics from NVR and cameras (default: false)
+    * `debug`: Use full type validation (default: false)
     """
 
     _minimum_score: int
+    _subscribed_models: Set[ModelType]
+    _ignore_stats: bool
     _bootstrap: Optional[Bootstrap] = None
     _last_update_dt: Optional[datetime] = None
     _ws_subscriptions: List[Callable[[WSSubscriptionMessage], None]] = []
@@ -463,6 +477,8 @@ class ProtectApiClient(BaseApiClient):
         verify_ssl: bool = True,
         session: Optional[aiohttp.ClientSession] = None,
         minimum_score: int = 0,
+        subscribed_models: Optional[Set[ModelType]] = None,
+        ignore_stats: bool = False,
         debug: bool = False,
     ) -> None:
         super().__init__(
@@ -470,6 +486,8 @@ class ProtectApiClient(BaseApiClient):
         )
 
         self._minimum_score = minimum_score
+        self._subscribed_models = subscribed_models or set()
+        self._ignore_stats = ignore_stats
 
         if debug:
             set_debug()
@@ -519,17 +537,19 @@ class ProtectApiClient(BaseApiClient):
             self._last_update_dt = max_event_dt
             self._last_websocket_check = NEVER_RAN
 
+        bootstrap_updated = False
         if self._bootstrap is None or now - self._last_update > DEVICE_UPDATE_INTERVAL:
+            bootstrap_updated = True
             self._last_update = now
             self._last_update_dt = now_dt
             self._bootstrap = await self.get_bootstrap()
 
         active_ws = await self.check_ws()
-        # If the websocket is connected/connecting
-        # we do not need to get events
-        if active_ws:
+        if not bootstrap_updated and active_ws:
+            # If the websocket is connected/connecting
+            # we do not need to get events
             _LOGGER.debug("Skipping update since websocket is active")
-            return None
+            return
 
         events = await self.get_events(start=self._last_update_dt or max_event_dt, end=now_dt)
         for event in events:
@@ -548,7 +568,9 @@ class ProtectApiClient(BaseApiClient):
 
     def _process_ws_message(self, msg: aiohttp.WSMessage) -> None:
         packet = WSPacket(msg.data)
-        processed_message = self.bootstrap.process_ws_packet(packet)
+        processed_message = self.bootstrap.process_ws_packet(
+            packet, models=self._subscribed_models, ignore_stats=self._ignore_stats
+        )
 
         if processed_message is None:
             return

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -8,7 +8,6 @@ from typing import (
     Any,
     ClassVar,
     Dict,
-    Iterable,
     List,
     Optional,
     Set,
@@ -36,6 +35,8 @@ from pyunifiprotect.utils import (
 )
 
 if TYPE_CHECKING:
+    from pydantic.typing import DictStrAny, SetStr
+
     from pyunifiprotect.api import ProtectApiClient
     from pyunifiprotect.data.devices import Bridge
     from pyunifiprotect.data.nvr import Event
@@ -57,12 +58,12 @@ class ProtectBaseObject(BaseModel):
     _initial_data: Dict[str, Any] = PrivateAttr()
 
     _protect_objs: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
-    _protect_objs_set: ClassVar[Optional[Iterable[str]]] = None
+    _protect_objs_set: ClassVar[Optional[SetStr]] = None
     _protect_lists: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
-    _protect_lists_set: ClassVar[Optional[Iterable[str]]] = None
+    _protect_lists_set: ClassVar[Optional[SetStr]] = None
     _protect_dicts: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
-    _protect_dicts_set: ClassVar[Optional[Iterable[str]]] = None
-    _to_unifi_remaps: ClassVar[Optional[Dict[str, str]]] = None
+    _protect_dicts_set: ClassVar[Optional[SetStr]] = None
+    _to_unifi_remaps: ClassVar[Optional[DictStrAny]] = None
 
     class Config:
         arbitrary_types_allowed = True
@@ -208,7 +209,7 @@ class ProtectBaseObject(BaseModel):
         if cls._protect_objs_set is None:
             cls._protect_objs_set = set(cls._get_protect_objs().keys())
 
-        return cls._protect_objs_set  # type: ignore
+        return cls._protect_objs_set
 
     @classmethod
     def _get_protect_lists(cls) -> Dict[str, Type[ProtectBaseObject]]:
@@ -225,7 +226,7 @@ class ProtectBaseObject(BaseModel):
         if cls._protect_lists_set is None:
             cls._protect_lists_set = set(cls._get_protect_lists().keys())
 
-        return cls._protect_lists_set  # type: ignore
+        return cls._protect_lists_set
 
     @classmethod
     def _get_protect_dicts(cls) -> Dict[str, Type[ProtectBaseObject]]:
@@ -242,7 +243,7 @@ class ProtectBaseObject(BaseModel):
         if cls._protect_dicts_set is None:
             cls._protect_dicts_set = set(cls._get_protect_dicts().keys())
 
-        return cls._protect_dicts_set  # type: ignore
+        return cls._protect_dicts_set
 
     @classmethod
     def _get_api(cls, api: Optional[ProtectApiClient]) -> Optional[ProtectApiClient]:

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -56,8 +56,12 @@ class ProtectBaseObject(BaseModel):
     _initial_data: Dict[str, Any] = PrivateAttr()
 
     _protect_objs: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
+    _protect_objs_set: ClassVar[Optional[Set[str]]] = None
     _protect_lists: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
+    _protect_lists_set: ClassVar[Optional[Set[str]]] = None
     _protect_dicts: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
+    _protect_dicts_set: ClassVar[Optional[Set[str]]] = None
+    _to_unifi_remaps: ClassVar[Optional[Dict[str, str]]] = None
 
     class Config:
         arbitrary_types_allowed = True
@@ -103,17 +107,24 @@ class ProtectBaseObject(BaseModel):
     @classmethod
     def construct(cls, _fields_set: Optional[Set[str]] = None, **values: Any) -> ProtectObject:
         api = values.pop("api", None)
-        for key, klass in cls._get_protect_objs().items():
-            if key in values and isinstance(values[key], dict):
-                values[key] = klass.construct(**values[key])
+        values_set = set(values)
 
-        for key, klass in cls._get_protect_lists().items():
-            if key in values and isinstance(values[key], list):
-                values[key] = [klass.construct(**v) if isinstance(v, dict) else v for v in values[key]]
+        unifi_objs = cls._get_protect_objs()
+        for key in cls._get_protect_objs_set().intersection(values_set):
+            if isinstance(values[key], dict):
+                values[key] = unifi_objs[key].construct(**values[key])
 
-        for key, klass in cls._get_protect_dicts().items():
-            if key in values and isinstance(values[key], dict):
-                values[key] = {k: klass.construct(**v) if isinstance(v, dict) else v for k, v in values[key].items()}
+        unifi_lists = cls._get_protect_lists()
+        for key in cls._get_protect_lists_set().intersection(values_set):
+            if isinstance(values[key], list):
+                values[key] = [unifi_lists[key].construct(**v) if isinstance(v, dict) else v for v in values[key]]
+
+        unifi_dicts = cls._get_protect_dicts()
+        for key in cls._get_protect_dicts_set().intersection(values_set):
+            if isinstance(values[key], dict):
+                values[key] = {
+                    k: unifi_dicts[key].construct(**v) if isinstance(v, dict) else v for k, v in values[key].items()
+                }
 
         obj = super().construct(_fields_set=_fields_set, **values)
         obj._initial_data = obj.dict(exclude=cls._get_excluded_changed_fields())  # pylint: disable=protected-access
@@ -142,6 +153,24 @@ class ProtectBaseObject(BaseModel):
         """
 
         return {}
+
+    @classmethod
+    def _get_to_unifi_remaps(cls) -> Dict[str, str]:
+        """
+        Helper method for overriding in child classes for reversing remap UFP
+        JSON keys to Python ones that do not fit the simple camel case to
+        snake case formula.
+
+        Return format is
+        {
+            "python_name": "ufpJsonName"
+        }
+        """
+
+        if cls._to_unifi_remaps is None:
+            cls._to_unifi_remaps = {to_key: from_key for from_key, to_key in cls._get_unifi_remaps().items()}
+
+        return cls._to_unifi_remaps
 
     @classmethod
     def _set_protect_subtypes(cls) -> None:
@@ -173,6 +202,14 @@ class ProtectBaseObject(BaseModel):
         return cls._protect_objs  # type: ignore
 
     @classmethod
+    def _get_protect_objs_set(cls) -> Set[str]:
+        """Helper method to get all child UFP objects"""
+        if cls._protect_objs_set is None:
+            cls._protect_objs_set = set(cls._get_protect_objs().keys())
+
+        return cls._protect_objs_set
+
+    @classmethod
     def _get_protect_lists(cls) -> Dict[str, Type[ProtectBaseObject]]:
         """Helper method to get all child of UFP objects (lists)"""
         if cls._protect_lists is not None:
@@ -182,6 +219,14 @@ class ProtectBaseObject(BaseModel):
         return cls._protect_lists  # type: ignore
 
     @classmethod
+    def _get_protect_lists_set(cls) -> Set[str]:
+        """Helper method to get all child UFP objects"""
+        if cls._protect_lists_set is None:
+            cls._protect_lists_set = set(cls._get_protect_lists().keys())
+
+        return cls._protect_lists_set
+
+    @classmethod
     def _get_protect_dicts(cls) -> Dict[str, Type[ProtectBaseObject]]:
         """Helper method to get all child of UFP objects (dicts)"""
         if cls._protect_dicts is not None:
@@ -189,6 +234,14 @@ class ProtectBaseObject(BaseModel):
 
         cls._set_protect_subtypes()
         return cls._protect_dicts  # type: ignore
+
+    @classmethod
+    def _get_protect_dicts_set(cls) -> Set[str]:
+        """Helper method to get all child UFP objects"""
+        if cls._protect_dicts_set is None:
+            cls._protect_dicts_set = set(cls._get_protect_dicts().keys())
+
+        return cls._protect_dicts_set
 
     @classmethod
     def _get_api(cls, api: Optional[ProtectApiClient]) -> Optional[ProtectApiClient]:
@@ -210,19 +263,17 @@ class ProtectBaseObject(BaseModel):
     def _clean_protect_obj_list(
         cls, items: List[Any], klass: Type[ProtectBaseObject], api: Optional[ProtectApiClient]
     ) -> List[Any]:
-        cleaned_items: List[Any] = []
-        for item in items:
-            cleaned_items.append(cls._clean_protect_obj(item, klass, api))
-        return cleaned_items
+        for index, item in enumerate(items):
+            items[index] = cls._clean_protect_obj(item, klass, api)
+        return items
 
     @classmethod
     def _clean_protect_obj_dict(
         cls, items: Dict[Any, Any], klass: Type[ProtectBaseObject], api: Optional[ProtectApiClient]
     ) -> Dict[Any, Any]:
-        cleaned_items: Dict[Any, Any] = {}
         for key, value in items.items():
-            cleaned_items[key] = cls._clean_protect_obj(value, klass, api)
-        return cleaned_items
+            items[key] = cls._clean_protect_obj(value, klass, api)
+        return items
 
     @classmethod
     def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -243,36 +294,40 @@ class ProtectBaseObject(BaseModel):
         api = cls._get_api(data.get("api", None))
 
         # remap keys that will not be converted correctly by snake_case convert
-        for from_key, to_key in cls._get_unifi_remaps().items():
-            if from_key in data:
-                data[to_key] = data.pop(from_key)
+        remaps = cls._get_unifi_remaps()
+        for from_key in set(remaps).intersection(data):
+            data[remaps[from_key]] = data.pop(from_key)
 
-        # convert to snake_case
+        # convert to snake_case and remove extra fields
         for key in list(data.keys()):
-            data[to_snake_case(key)] = data.pop(key)
+            new_key = to_snake_case(key)
+            data[new_key] = data.pop(key)
+            key = new_key
 
-        # remove extra fields
-        for key, value in list(data.items()):
             if key == "api":
                 continue
 
             if key not in cls.__fields__:
                 del data[key]
                 continue
-            data[key] = convert_unifi_data(value, cls.__fields__[key])
+            data[key] = convert_unifi_data(data[key], cls.__fields__[key])
 
         # clean child UFP objs
-        for key, klass in cls._get_protect_objs().items():
-            if key in data:
-                data[key] = cls._clean_protect_obj(data[key], klass, api)
+        data_set = set(data)
 
-        for key, klass in cls._get_protect_lists().items():
-            if key in data and isinstance(data[key], list):
-                data[key] = cls._clean_protect_obj_list(data[key], klass, api)
+        unifi_objs = cls._get_protect_objs()
+        for key in cls._get_protect_objs_set().intersection(data_set):
+            data[key] = cls._clean_protect_obj(data[key], unifi_objs[key], api)
 
-        for key, klass in cls._get_protect_dicts().items():
-            if key in data and isinstance(data[key], dict):
-                data[key] = cls._clean_protect_obj_dict(data[key], klass, api)
+        unifi_lists = cls._get_protect_lists()
+        for key in cls._get_protect_lists_set().intersection(data_set):
+            if isinstance(data[key], list):
+                data[key] = cls._clean_protect_obj_list(data[key], unifi_lists[key], api)
+
+        unifi_dicts = cls._get_protect_dicts()
+        for key in cls._get_protect_dicts_set().intersection(data_set):
+            if isinstance(data[key], dict):
+                data[key] = cls._clean_protect_obj_dict(data[key], unifi_dicts[key], api)
 
         return data
 
@@ -336,7 +391,7 @@ class ProtectBaseObject(BaseModel):
 
         use_obj = False
         if data is None:
-            excluded_fields = set(self._get_protect_objs().keys()) | set(self._get_protect_lists().keys())
+            excluded_fields = self._get_protect_objs_set() | self._get_protect_lists_set()
             if exclude is not None:
                 excluded_fields = excluded_fields | exclude
             data = self.dict(exclude=excluded_fields)
@@ -355,9 +410,9 @@ class ProtectBaseObject(BaseModel):
                 data[key] = self._unifi_dict_protect_obj_dict(data, key, use_obj)
 
         data: Dict[str, Any] = serialize_unifi_obj(data)
-        for to_key, from_key in self._get_unifi_remaps().items():
-            if from_key in data:
-                data[to_key] = data.pop(from_key)
+        remaps = self._get_to_unifi_remaps()
+        for to_key in set(data).intersection(remaps):
+            data[remaps[to_key]] = data.pop(to_key)
 
         if "api" in data:
             del data["api"]
@@ -368,12 +423,12 @@ class ProtectBaseObject(BaseModel):
         data["api"] = api
         data_set = set(data)
 
-        for key in data_set.intersection(self._get_protect_objs()):
+        for key in self._get_protect_objs_set().intersection(data_set):
             unifi_obj: Optional[Any] = getattr(self, key)
             if unifi_obj is not None and isinstance(unifi_obj, dict):
                 unifi_obj["api"] = api
 
-        for key in data_set.intersection(self._get_protect_lists()):
+        for key in self._get_protect_lists_set().intersection(data_set):
             new_items = []
             for item in data[key]:
                 if isinstance(item, dict):
@@ -381,7 +436,7 @@ class ProtectBaseObject(BaseModel):
                 new_items.append(item)
             data[key] = new_items
 
-        for key in data_set.intersection(self._get_protect_dicts()):
+        for key in self._get_protect_dicts_set().intersection(data_set):
             for item_key, item in data[key].items():
                 if isinstance(item, dict):
                     item["api"] = api
@@ -392,18 +447,17 @@ class ProtectBaseObject(BaseModel):
     def update_from_dict(self: ProtectObject, data: Dict[str, Any]) -> ProtectObject:
         """Updates current object from a cleaned UFP JSON dict"""
         data_set = set(data)
-        for key in data_set.intersection(self._get_protect_objs()):
+        for key in self._get_protect_objs_set().intersection(data_set):
             unifi_obj: Optional[Any] = getattr(self, key)
             if unifi_obj is not None and isinstance(unifi_obj, ProtectBaseObject):
                 setattr(self, key, unifi_obj.update_from_dict(data.pop(key)))
 
         data = self._inject_api(data, self._api)
-        protect_lists = self._get_protect_lists()
-
-        for key in data_set.intersection(protect_lists):
+        unifi_lists = self._get_protect_lists()
+        for key in self._get_protect_lists_set().intersection(data_set):
             if not isinstance(data[key], list):
                 continue
-            klass = protect_lists[key]
+            klass = unifi_lists[key]
             new_items = []
             for item in data.pop(key):
                 if item is not None and isinstance(item, ProtectBaseObject):

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -8,6 +8,7 @@ from typing import (
     Any,
     ClassVar,
     Dict,
+    Iterable,
     List,
     Optional,
     Set,
@@ -56,11 +57,11 @@ class ProtectBaseObject(BaseModel):
     _initial_data: Dict[str, Any] = PrivateAttr()
 
     _protect_objs: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
-    _protect_objs_set: ClassVar[Optional[Set[str]]] = None
+    _protect_objs_set: ClassVar[Optional[Iterable[str]]] = None
     _protect_lists: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
-    _protect_lists_set: ClassVar[Optional[Set[str]]] = None
+    _protect_lists_set: ClassVar[Optional[Iterable[str]]] = None
     _protect_dicts: ClassVar[Optional[Dict[str, Type[ProtectBaseObject]]]] = None
-    _protect_dicts_set: ClassVar[Optional[Set[str]]] = None
+    _protect_dicts_set: ClassVar[Optional[Iterable[str]]] = None
     _to_unifi_remaps: ClassVar[Optional[Dict[str, str]]] = None
 
     class Config:
@@ -207,7 +208,7 @@ class ProtectBaseObject(BaseModel):
         if cls._protect_objs_set is None:
             cls._protect_objs_set = set(cls._get_protect_objs().keys())
 
-        return cls._protect_objs_set
+        return cls._protect_objs_set  # type: ignore
 
     @classmethod
     def _get_protect_lists(cls) -> Dict[str, Type[ProtectBaseObject]]:
@@ -224,7 +225,7 @@ class ProtectBaseObject(BaseModel):
         if cls._protect_lists_set is None:
             cls._protect_lists_set = set(cls._get_protect_lists().keys())
 
-        return cls._protect_lists_set
+        return cls._protect_lists_set  # type: ignore
 
     @classmethod
     def _get_protect_dicts(cls) -> Dict[str, Type[ProtectBaseObject]]:
@@ -241,7 +242,7 @@ class ProtectBaseObject(BaseModel):
         if cls._protect_dicts_set is None:
             cls._protect_dicts_set = set(cls._get_protect_dicts().keys())
 
-        return cls._protect_dicts_set
+        return cls._protect_dicts_set  # type: ignore
 
     @classmethod
     def _get_api(cls, api: Optional[ProtectApiClient]) -> Optional[ProtectApiClient]:

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -33,9 +33,8 @@ EVENT_ATTR_MAP: Dict[EventType, Tuple[str, str]] = {
 
 def _remove_stats_keys(data: Dict[str, Any], ignore_stats: bool) -> Dict[str, Any]:
     if ignore_stats:
-        for key in list(data.keys()):
-            if key in STATS_KEYS:
-                del data[key]
+        for key in STATS_KEYS.intersection(data.keys()):
+            del data[key]
     return data
 
 

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -31,6 +31,14 @@ EVENT_ATTR_MAP: Dict[EventType, Tuple[str, str]] = {
 }
 
 
+def _remove_stats_keys(data: Dict[str, Any], ignore_stats: bool):
+    if ignore_stats:
+        for key in list(data.keys()):
+            if key in STATS_KEYS:
+                del data[key]
+    return data
+
+
 class Bootstrap(ProtectBaseObject):
     auth_user_id: str
     access_key: str
@@ -144,13 +152,10 @@ class Bootstrap(ProtectBaseObject):
         if action["action"] == "update":
             model_type = action["modelKey"]
             if model_type == ModelType.NVR.value:
-                if ignore_stats:
-                    for key in list(data.keys()):
-                        if key in STATS_KEYS:
-                            del data[key]
-                    # nothing left to process
-                    if data == {}:
-                        return None
+                data = _remove_stats_keys(data, ignore_stats)
+                # nothing left to process
+                if data == {}:
+                    return None
 
                 data = self.nvr.unifi_dict_to_dict(data)
                 old_nvr = self.nvr.copy()
@@ -164,11 +169,8 @@ class Bootstrap(ProtectBaseObject):
                     old_obj=old_nvr,
                 )
             if model_type in ModelType.bootstrap_models() or model_type == ModelType.EVENT.value:
-
-                if model_type == ModelType.CAMERA.value and ignore_stats:
-                    for key in list(data.keys()):
-                        if key in STATS_KEYS:
-                            del data[key]
+                if model_type == ModelType.CAMERA.value:
+                    data = _remove_stats_keys(data, ignore_stats)
                     # nothing left to process
                     if data == {}:
                         return None

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -31,7 +31,7 @@ EVENT_ATTR_MAP: Dict[EventType, Tuple[str, str]] = {
 }
 
 
-def _remove_stats_keys(data: Dict[str, Any], ignore_stats: bool):
+def _remove_stats_keys(data: Dict[str, Any], ignore_stats: bool) -> Dict[str, Any]:
     if ignore_stats:
         for key in list(data.keys()):
             if key in STATS_KEYS:

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -118,7 +118,7 @@ class Bootstrap(ProtectBaseObject):
             return None
 
         if len(models) > 0 and ModelType(action["modelKey"]) not in models:
-            return
+            return None
 
         if action["action"] == "add":
             obj = create_from_unifi_dict(data, api=self._api)
@@ -150,7 +150,7 @@ class Bootstrap(ProtectBaseObject):
                             del data[key]
                     # nothing left to process
                     if data == {}:
-                        return
+                        return None
 
                 data = self.nvr.unifi_dict_to_dict(data)
                 old_nvr = self.nvr.copy()
@@ -171,7 +171,7 @@ class Bootstrap(ProtectBaseObject):
                             del data[key]
                     # nothing left to process
                     if data == {}:
-                        return
+                        return None
 
                 key = model_type + "s"
                 devices = getattr(self, key)

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -54,6 +54,7 @@ class SubscriptionTest:
             self.unsub()
 
 
+@pytest.mark.benchmark(group="websockets")
 @pytest.mark.asyncio
 async def test_ws_all(
     protect_client_ws: ProtectApiClient, ws_messages: Dict[str, Dict[str, Any]], benchmark: BenchmarkFixture

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -16,6 +16,7 @@ from pyunifiprotect import ProtectApiClient
 from pyunifiprotect.data import EventType, WSPacket
 from pyunifiprotect.data.base import ProtectModel
 from pyunifiprotect.data.devices import Camera
+from pyunifiprotect.data.types import ModelType
 from pyunifiprotect.data.websocket import (
     WSAction,
     WSJSONPacketFrame,
@@ -91,6 +92,48 @@ async def test_ws_all(
     assert ws_connect.count == len(ws_messages)
     assert ws_connect.now == float(list(ws_messages.keys())[-1])
     assert sub.callback_count == 3
+
+
+@pytest.mark.benchmark(group="websockets")
+@pytest.mark.asyncio
+async def test_ws_filtered(protect_client_ws: ProtectApiClient, benchmark: BenchmarkFixture):
+    protect_client = protect_client_ws
+    protect_client._ignore_stats = True
+    protect_client._subscribed_models = {
+        ModelType.EVENT,
+        ModelType.CAMERA,
+        ModelType.LIGHT,
+        ModelType.VIEWPORT,
+        ModelType.SENSOR,
+        ModelType.LIVEVIEW,
+    }
+    sub = SubscriptionTest()
+    sub.unsub = protect_client.subscribe_websocket(sub.callback)
+    _orig = protect_client.bootstrap.process_ws_packet
+
+    stats = benchmark._make_stats(1)
+
+    def benchmark_process_ws_packet(*args, **kwargs):
+        runner = benchmark._make_runner(_orig, args, kwargs)
+        duration, result = runner(None)
+        stats.update(duration)
+
+        return result
+
+    # bypass pydantic checks
+    object.__setattr__(protect_client.bootstrap, "process_ws_packet", benchmark_process_ws_packet)
+
+    # wait for ws connection
+    for _ in range(60):
+        if protect_client.is_ws_connected:
+            break
+        await asyncio.sleep(0.5)
+
+    ws_connect: Optional[MockWebsocket] = protect_client._ws_connection  # type: ignore
+    assert ws_connect is not None
+
+    while protect_client.is_ws_connected:
+        await asyncio.sleep(0.1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -169,6 +169,7 @@ def test_bootstrap(bootstrap):
     assert obj == obj_construct
 
 
+@pytest.mark.benchmark(group="construct")
 def test_bootstrap_benchmark(bootstrap, benchmark: BenchmarkFixture):
     def create():
         Bootstrap.from_unifi_dict(**deepcopy(bootstrap))
@@ -176,6 +177,7 @@ def test_bootstrap_benchmark(bootstrap, benchmark: BenchmarkFixture):
     benchmark.pedantic(create, rounds=50, iterations=5)
 
 
+@pytest.mark.benchmark(group="construct")
 def test_bootstrap_benchmark_construct(bootstrap, benchmark: BenchmarkFixture):
     set_no_debug()
 


### PR DESCRIPTION
* Increases Bootstrap poll interval to 15 minutes if WS is activate. Does not need to be polled every 60 seconds
* Adds arguments to ignore a number of events from WS
* Adds test to benchmark processing Websocket packets
* Optimizes `update_from_dict` to not call `.copy` or `.construct`.

No optimization:
![image](https://user-images.githubusercontent.com/490848/144510249-dbaefc3b-6fdb-498b-b54a-7d69c34f3b13.png)

With optimizations: 
![image](https://user-images.githubusercontent.com/490848/144513364-d0e22fe4-a5e6-4d32-bba5-e7dafbd8c0f9.png)

second pass optimizations: 
![image](https://user-images.githubusercontent.com/490848/144528097-40e26087-1481-4ec9-a222-5e8e79de0f37.png)


The `test_ws_filtered` is closer to what the HA performance gains should be. The only difference there is that NVR messages were ignored for that test to improve coverage. 

About a ~35% performance increase on the mean process time for the `update_from_dict` optimizations and then an additional 25% (52% total) increase filtering out WS messages.
