### PR TITLE
Creates release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  deploy:
+    name: Publish to PyPi
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check repo
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build package
+      run: python -m build
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   deploy:
     name: Publish to PyPi
     runs-on: ubuntu-latest
+    environment: PyPi
 
     steps:
     - name: Check repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
   deploy:
     name: Publish to PyPi
     runs-on: ubuntu-latest
-    environment: PyPi
 
     steps:
     - name: Check repo


### PR DESCRIPTION
This workflow needs a PyPi API token secret added to use.

1. Go to https://pypi.org/manage/account/token/
2. Create a token for "Project: pyunifiprotect"
3. Go to https://github.com/briis/pyunifiprotect/settings/secrets/actions
4. Add "New repository secret" named `PYPI_API_TOKEN` with the value from above
