### PR TITLE
Adds option to override connection host

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -461,6 +461,7 @@ class ProtectApiClient(BaseApiClient):
     * `password`: UFP password
     * `verify_ssl`: Verify HTTPS certificate (default: `True`)
     * `session`: Optional aiohttp session to use (default: generate one)
+    * `override_connection_host`: Use `host` as your `connection_host` for RTSP stream instead of using the one provided by UniFi Protect.
     * `minimum_score`: minimum score for events (default: `0`)
     * `subscribed_models`: Model types you want to filter events for WS. You will need to manually check the bootstrap for updates for events that not subscibred.
     * `ignore_stats`: Ignore storage, system, etc. stats/metrics from NVR and cameras (default: false)
@@ -483,18 +484,27 @@ class ProtectApiClient(BaseApiClient):
         password: str,
         verify_ssl: bool = True,
         session: Optional[aiohttp.ClientSession] = None,
+        override_connection_host: bool = False,
         minimum_score: int = 0,
         subscribed_models: Optional[Set[ModelType]] = None,
         ignore_stats: bool = False,
         debug: bool = False,
     ) -> None:
         super().__init__(
-            host=host, port=port, username=username, password=password, verify_ssl=verify_ssl, session=session
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            verify_ssl=verify_ssl,
+            session=session,
         )
 
         self._minimum_score = minimum_score
         self._subscribed_models = subscribed_models or set()
         self._ignore_stats = ignore_stats
+
+        if override_connection_host:
+            self._connection_host = ip_from_host(self._host)
 
         if debug:
             set_debug()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -184,6 +184,13 @@ def test_connection_host(protect_client: ProtectApiClient):
     assert protect_client.connection_host == IPv4Address("192.168.3.1")
 
 
+def test_connection_host_override():
+    protect = ProtectApiClient("127.0.0.1", 443, "test", "test", override_connection_host=True)
+
+    expected = IPv4Address("127.0.0.1")
+    assert protect._connection_host == expected
+
+
 @pytest.mark.asyncio
 async def test_force_update(protect_client: ProtectApiClient):
     protect_client._bootstrap = None


### PR DESCRIPTION
Let's users match their `connection_host` to their `host`. Would allow access RTSP streams over the Internet.