### PR TITLE
Play audio without blocking until completion

### DIFF
--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -1021,7 +1021,7 @@ class Camera(ProtectMotionDeviceModel):
         self.talkback_stream = TalkbackStream(self, content_url, ffmpeg_path)
         return self.talkback_stream
 
-    async def play_audio(self, content_url: str, ffmpeg_path: Optional[Path] = None) -> None:
+    async def play_audio(self, content_url: str, ffmpeg_path: Optional[Path] = None, blocking: bool = True) -> None:
         """
         Plays audio to a camera through its speaker.
 
@@ -1031,9 +1031,21 @@ class Camera(ProtectMotionDeviceModel):
 
         * `content_url`: Either a URL accessible by python or a path to a file (ffmepg's `-i` parameter)
         * `ffmpeg_path`: Optional path to ffmpeg binary
+        * `blocking`: Awaits stream completion and logs stdout/stderr
         """
 
         stream = self.create_talkback_stream(content_url, ffmpeg_path)
+        await stream.start()
+
+        if blocking:
+            await self.wait_until_audio_completes()
+
+    async def wait_until_audio_completes(self) -> None:
+        """Awaits stream completion of audio and logs stdout/stderr."""
+
+        stream = self.talkback_stream
+        if stream is None:
+            raise StreamError("No audio playing to wait for")
 
         await stream.run_until_complete()
 

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -1055,7 +1055,7 @@ class Camera(ProtectMotionDeviceModel):
             error = "\n".join(stream.stderr)
             raise StreamError("Error while playing audio (ffmpeg): \n" + error)
 
-    async def stop_audio(self):
+    async def stop_audio(self) -> None:
         """Stop currently playing audio."""
         stream = self.talkback_stream
         if stream is None:

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -1055,6 +1055,14 @@ class Camera(ProtectMotionDeviceModel):
             error = "\n".join(stream.stderr)
             raise StreamError("Error while playing audio (ffmpeg): \n" + error)
 
+    async def stop_audio(self):
+        """Stop currently playing audio."""
+        stream = self.talkback_stream
+        if stream is None:
+            raise StreamError("No audio playing to stop")
+
+        await stream.stop()
+
 
 class Viewer(ProtectAdoptableDeviceModel):
     stream_limit: int

--- a/pyunifiprotect/stream.py
+++ b/pyunifiprotect/stream.py
@@ -91,10 +91,9 @@ class FfmpegCommand:
                 break
 
     async def run_until_complete(self) -> None:
-        if self.is_started:
-            raise StreamError("ffmpeg command already started")
+        if not self.is_started:
+            await self.start()
 
-        await self.start()
         if self.process is None:
             raise StreamError("Could not start stream")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -508,5 +508,7 @@ class MockTalkback:
     stdout: List[str] = []
     stderr: List[str] = []
 
-    start = AsyncMock()
-    run_until_complete = AsyncMock()
+    def __init__(self) -> None:
+        self.start = AsyncMock()
+        self.stop = AsyncMock()
+        self.run_until_complete = AsyncMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -508,4 +508,5 @@ class MockTalkback:
     stdout: List[str] = []
     stderr: List[str] = []
 
+    start = AsyncMock()
     run_until_complete = AsyncMock()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -310,7 +310,25 @@ async def test_play_audio(mock_talkback, camera_obj: Camera):
     await camera_obj.play_audio("test")
 
     mock_talkback.assert_called_with(camera_obj, "test", None)
+    assert mock_instance.start.called
     assert mock_instance.run_until_complete.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_camera_validation")
+@patch("pyunifiprotect.data.devices.TalkbackStream")
+async def test_play_audio_no_blocking(mock_talkback, camera_obj: Camera):
+    camera_obj.feature_flags.has_speaker = True
+    camera_obj._initial_data = camera_obj.dict()
+
+    mock_instance = MockTalkback()
+    mock_talkback.return_value = mock_instance
+
+    await camera_obj.play_audio("test", blocking=False)
+
+    mock_talkback.assert_called_with(camera_obj, "test", None)
+    assert mock_instance.start.called
+    assert not mock_instance.run_until_complete.called
 
 
 @pytest.mark.asyncio

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -337,6 +337,26 @@ async def test_play_audio_no_blocking(mock_talkback, camera_obj: Camera):
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("disable_camera_validation")
 @patch("pyunifiprotect.data.devices.TalkbackStream")
+async def test_play_audio_stop(mock_talkback, camera_obj: Camera):
+    camera_obj.feature_flags.has_speaker = True
+    camera_obj._initial_data = camera_obj.dict()
+
+    mock_instance = MockTalkback()
+    mock_talkback.return_value = mock_instance
+
+    await camera_obj.play_audio("test", blocking=False)
+
+    mock_talkback.assert_called_with(camera_obj, "test", None)
+    assert mock_instance.start.called
+    assert not mock_instance.run_until_complete.called
+
+    await camera_obj.stop_audio()
+    assert mock_instance.stop.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("disable_camera_validation")
+@patch("pyunifiprotect.data.devices.TalkbackStream")
 async def test_play_audio_error(mock_talkback, camera_obj: Camera):
     camera_obj.feature_flags.has_speaker = True
     camera_obj._initial_data = camera_obj.dict()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -330,6 +330,9 @@ async def test_play_audio_no_blocking(mock_talkback, camera_obj: Camera):
     assert mock_instance.start.called
     assert not mock_instance.run_until_complete.called
 
+    await camera_obj.wait_until_audio_completes()
+    assert mock_instance.run_until_complete.called
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("disable_camera_validation")


### PR DESCRIPTION
I realized that HA never updates the speaker state because UniFi Protect does not send WS messages about talkback. This will let us start playing audio, update speaker state and then block until completion so we can update speaker state again.