### PR TITLE
Improves logging around WS connects/disconnects

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -430,11 +430,7 @@ class BaseApiClient:
                 log = _LOGGER.warning
             log("Websocket connection not active, failing back to polling")
 
-        if self._ws_connection or self._last_websocket_check == now:
-            new_status = True
-        else:
-            new_status = False
-
+        new_status = self.is_ws_connected or self._last_websocket_check == now
         if not self._last_websocket_status and new_status:
             _LOGGER.info("Websocket connection successfully connected")
 

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -84,6 +84,7 @@ class BaseApiClient:
     _is_authenticated: bool = False
     _last_update: float = NEVER_RAN
     _last_websocket_check: float = NEVER_RAN
+    _last_websocket_status: bool = False
     _session: Optional[aiohttp.ClientSession] = None
     _ws_session: Optional[aiohttp.ClientSession] = None
     _ws_connection: Optional[aiohttp.ClientWebSocketResponse] = None
@@ -416,24 +417,29 @@ class BaseApiClient:
         now = time.monotonic()
 
         first_check = self._last_websocket_check == NEVER_RAN
-        connect_ws = False
         if now - self._last_websocket_check > WEBSOCKET_CHECK_INTERVAL:
             _LOGGER.debug("Checking websocket")
             self._last_websocket_check = now
-            connect_ws = True
             await self.async_connect_ws()
 
         # log if no active WS
-        if not self._ws_connection and not first_check:
+        if not self.is_ws_connected and not first_check:
             log = _LOGGER.debug
             # but only warn if a reconnect attempt was made
-            if connect_ws:
+            if self._last_websocket_status:
                 log = _LOGGER.warning
-            log("Unifi OS: Websocket connection not active, failing back to polling")
+            log("Websocket connection not active, failing back to polling")
 
         if self._ws_connection or self._last_websocket_check == now:
-            return True
-        return False
+            new_status = True
+        else:
+            new_status = False
+
+        if not self._last_websocket_status and new_status:
+            _LOGGER.info("Websocket connection successfully connected")
+
+        self._last_websocket_status = new_status
+        return self._last_websocket_status
 
     def _process_ws_message(self, msg: aiohttp.WSMessage) -> None:
         raise NotImplementedError()

--- a/pyunifiprotect/cli.py
+++ b/pyunifiprotect/cli.py
@@ -176,6 +176,8 @@ def shell(
 
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(levelname)s: %(message)s")
+    console_handler.setFormatter(formatter)
     _LOGGER.setLevel(logging.DEBUG)
     _LOGGER.addHandler(console_handler)
 


### PR DESCRIPTION
This should greatly improve the logging consistency for WS connects/disconnects. A "warning" message will be posted as soon as the WS disconnects and then an "info" message will be posted as soon as it reconnects. Also adds logging level to shell output.

Good way to test:

In VS Code Dev container:

1. Run `Subcommand: shell` debug task
2. Run the following code, it should simulate the HA update loop close enough:

    ```python
    from pyunifiprotect import NvrError
    force = False
    while True:
        try:
            await protect.update(force=force)
        except NvrError:
            force = True
        else:
            force = False
        await asyncio.sleep(5)
    ```

3. Update/downgrade UniFi Protect version (from UNVR cli, if you are doing beta version, you need to use UniFi OS WebUI):

    ```bash
        apt-get install --reinstall --allow-downgrades unifi-protect=1.20.2 -y
    ```