### PR TITLE
Improves is_ attrs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,6 @@
             "module": "pyunifiprotect",
             "args": [
                 "shell",
-                "-n",
             ]
         },
         {

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -324,8 +324,9 @@ class BaseApiClient:
             try:
                 self._ws_task.cancel()
                 self._ws_connection = None
-                self._ws_session.close()
-                self._ws_session = None
+                if self._ws_session is not None:
+                    self._ws_session.close()
+                    self._ws_session = None
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Could not cancel WS task")
 

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -324,6 +324,8 @@ class BaseApiClient:
             try:
                 self._ws_task.cancel()
                 self._ws_connection = None
+                self._ws_session.close()
+                self._ws_session = None
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Could not cancel WS task")
 

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -319,20 +319,23 @@ class BaseApiClient:
         if not self.is_ws_connected:
             return
 
+        _LOGGER.debug("Canceling WS task...")
         if self._ws_task is not None:
             try:
                 self._ws_task.cancel()
                 self._ws_connection = None
             except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Could not cancel ws_task")
+                _LOGGER.exception("Could not cancel WS task")
 
     async def async_connect_ws(self) -> None:
         """Connect the websocket."""
 
-        if self.is_ws_connected:
+        # do not try to connect if already connected or connect scheduled
+        if self.is_ws_connected or self._ws_task is not None:
             return
 
         self.reset_ws()
+        _LOGGER.debug("Scheduling WS connect...")
         self._ws_task = asyncio.ensure_future(self._setup_websocket())
 
     async def async_disconnect_ws(self) -> None:
@@ -380,6 +383,7 @@ class BaseApiClient:
         finally:
             _LOGGER.debug("websocket disconnected")
             self._ws_connection = None
+            self._ws_task = None
 
     def subscribe_raw_websocket(self, ws_callback: Callable[[aiohttp.WSMessage], None]) -> Callable[[], None]:
         """

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -1,6 +1,7 @@
 """Unifi Protect Data."""
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
 from typing import (
@@ -44,6 +45,8 @@ if TYPE_CHECKING:
 
 
 ProtectObject = TypeVar("ProtectObject", bound="ProtectBaseObject")
+RECENT_EVENT_MAX = timedelta(seconds=30)
+EVENT_PING_INTERVAL = timedelta(seconds=3)
 
 
 class ProtectBaseObject(BaseModel):
@@ -602,6 +605,10 @@ class ProtectDeviceModel(ProtectModelWithId):
             data["hardwareRevision"] = str(data["hardwareRevision"])
 
         return super().unifi_dict_to_dict(data)
+
+    def _event_callback_ping(self) -> None:
+        loop = asyncio.get_event_loop()
+        loop.call_later(EVENT_PING_INTERVAL.total_seconds(), asyncio.create_task, self.emit_message({}))
 
 
 class WiredConnectionState(ProtectBaseObject):

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -573,6 +573,7 @@ class ProtectModelWithId(ProtectModel):
         data_frame.header = header
         data_frame.data = updated
 
+        print("emit_message")
         message = self.api.bootstrap.process_ws_packet(WSPacket(action_frame.packed + data_frame.packed))
         if message is not None:
             self.api.emit_message(message)
@@ -608,6 +609,7 @@ class ProtectDeviceModel(ProtectModelWithId):
 
     def _event_callback_ping(self) -> None:
         loop = asyncio.get_event_loop()
+        print("create_ping_task")
         loop.call_later(EVENT_PING_INTERVAL.total_seconds(), asyncio.create_task, self.emit_message({}))
 
 

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -573,7 +573,6 @@ class ProtectModelWithId(ProtectModel):
         data_frame.header = header
         data_frame.data = updated
 
-        print("emit_message")
         message = self.api.bootstrap.process_ws_packet(WSPacket(action_frame.packed + data_frame.packed))
         if message is not None:
             self.api.emit_message(message)
@@ -609,7 +608,6 @@ class ProtectDeviceModel(ProtectModelWithId):
 
     def _event_callback_ping(self) -> None:
         loop = asyncio.get_event_loop()
-        print("create_ping_task")
         loop.call_later(EVENT_PING_INTERVAL.total_seconds(), asyncio.create_task, self.emit_message({}))
 
 

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -277,7 +277,6 @@ class Bootstrap(ProtectBaseObject):
             if isinstance(obj, Event):
                 self.process_event(obj)
             elif isinstance(obj, Camera):
-                print("last_ring", obj.last_ring, now)
                 if "last_ring" in data and obj.last_ring and obj.last_ring + RECENT_EVENT_MAX >= now:
                     print("set_ring_timeout")
                     obj.set_ring_timeout()

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -1,7 +1,6 @@
 """Unifi Protect Bootstrap."""
 from __future__ import annotations
 
-import asyncio
 from copy import deepcopy
 from dataclasses import dataclass
 import logging
@@ -11,20 +10,13 @@ from uuid import UUID
 from pydantic.fields import PrivateAttr
 
 from pyunifiprotect.data.base import (
+    RECENT_EVENT_MAX,
     ProtectBaseObject,
-    ProtectDeviceModel,
     ProtectModel,
     ProtectModelWithId,
 )
 from pyunifiprotect.data.convert import create_from_unifi_dict
-from pyunifiprotect.data.devices import (
-    EVENT_PING_INTERVAL,
-    Bridge,
-    Camera,
-    Light,
-    Sensor,
-    Viewer,
-)
+from pyunifiprotect.data.devices import Bridge, Camera, Light, Sensor, Viewer
 from pyunifiprotect.data.nvr import NVR, Event, Group, Liveview, User
 from pyunifiprotect.data.types import EventType, FixSizeOrderedDict, ModelType
 from pyunifiprotect.data.websocket import (
@@ -33,6 +25,7 @@ from pyunifiprotect.data.websocket import (
     WSPacket,
     WSSubscriptionMessage,
 )
+from pyunifiprotect.utils import utc_now
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -107,11 +100,6 @@ def _process_camera_event(event: Event) -> None:
     dt = getattr(event.camera, dt_attr)
     if dt is None or event.start >= dt or (event.end is not None and event.end >= dt):
         setattr(event.camera, event_attr, event.id)
-
-
-def _event_callback_ping(obj: ProtectDeviceModel) -> None:
-    loop = asyncio.get_event_loop()
-    loop.call_later(EVENT_PING_INTERVAL.total_seconds(), obj.emit_message, {})
 
 
 @dataclass
@@ -284,17 +272,26 @@ class Bootstrap(ProtectBaseObject):
             data = obj.unifi_dict_to_dict(data)
             old_obj = obj.copy()
             obj = obj.update_from_dict(deepcopy(data))
+            now = utc_now()
 
             if isinstance(obj, Event):
                 self.process_event(obj)
             elif isinstance(obj, Camera):
-                if "last_ring" in data and obj.is_ringing:
-                    _event_callback_ping(obj)
+                if "last_ring" in data and obj.last_ring and obj.last_ring + RECENT_EVENT_MAX < now:
+                    obj.set_ring_timeout()
             elif isinstance(obj, Sensor):
-                if "alarm_triggered_at" in data and obj.is_alarm_detected:
-                    _event_callback_ping(obj)
-                elif "tampering_detected_at" in data and obj.is_tampering_detected:
-                    _event_callback_ping(obj)
+                if (
+                    "alarm_triggered_at" in data
+                    and obj.alarm_triggered_at
+                    and obj.alarm_triggered_at + RECENT_EVENT_MAX < now
+                ):
+                    obj.set_alarm_timeout()
+                elif (
+                    "tampering_detected_at" in data
+                    and obj.tampering_detected_at
+                    and obj.tampering_detected_at + RECENT_EVENT_MAX < now
+                ):
+                    obj.set_tampering_timeout()
 
             devices[action["id"]] = obj
 

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -277,19 +277,21 @@ class Bootstrap(ProtectBaseObject):
             if isinstance(obj, Event):
                 self.process_event(obj)
             elif isinstance(obj, Camera):
-                if "last_ring" in data and obj.last_ring and obj.last_ring + RECENT_EVENT_MAX < now:
+                print("last_ring", obj.last_ring, now)
+                if "last_ring" in data and obj.last_ring and obj.last_ring + RECENT_EVENT_MAX >= now:
+                    print("set_ring_timeout")
                     obj.set_ring_timeout()
             elif isinstance(obj, Sensor):
                 if (
                     "alarm_triggered_at" in data
                     and obj.alarm_triggered_at
-                    and obj.alarm_triggered_at + RECENT_EVENT_MAX < now
+                    and obj.alarm_triggered_at + RECENT_EVENT_MAX >= now
                 ):
                     obj.set_alarm_timeout()
                 elif (
                     "tampering_detected_at" in data
                     and obj.tampering_detected_at
-                    and obj.tampering_detected_at + RECENT_EVENT_MAX < now
+                    and obj.tampering_detected_at + RECENT_EVENT_MAX >= now
                 ):
                     obj.set_tampering_timeout()
 

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -278,7 +278,6 @@ class Bootstrap(ProtectBaseObject):
                 self.process_event(obj)
             elif isinstance(obj, Camera):
                 if "last_ring" in data and obj.last_ring and obj.last_ring + RECENT_EVENT_MAX >= now:
-                    print("set_ring_timeout")
                     obj.set_ring_timeout()
             elif isinstance(obj, Sensor):
                 if (

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -26,7 +26,12 @@ from pyunifiprotect.data.websocket import (
     WSSubscriptionMessage,
 )
 from pyunifiprotect.utils import print_ws_stat_summary, to_js_time, utc_now
-from tests.conftest import TEST_CAMERA_EXISTS, TEST_SENSOR_EXISTS, MockDatetime, MockWebsocket
+from tests.conftest import (
+    TEST_CAMERA_EXISTS,
+    TEST_SENSOR_EXISTS,
+    MockDatetime,
+    MockWebsocket,
+)
 
 PACKET_RAW = "AQEBAAAAAHR4nCXMQQrCMBBA0auUWRvIpJOm8Qbi2gNMZiZQ0NRFqIh4dwluP7z/AZa+7Q3OE7AqnCZo9ro9lbtddFRPhCayuOorOyqYXfEJXcprEqQZ55UHe+xq96u9h7HDWh9x+y+UqeZAsUrQrCFajFQWgu8PBLYjMAIBAQAAAAC2eJxVjr0KwzAMhF8leO6QOLZDOrdT126lg2PLxRA7wVYKIeTdK1PoD2jQfTodtzFcZ2DHiiUfH+xQsYw6IYFGtbyplaKRnDhE+0u7N81mSuW9LnugzxMgGLxSaCZ8u//z8xMifg4BUFuNmvS2kzY6QCqKdaaXsrNOcSN1ywfbgXGtg1JwpjSPfopkjMs4EloypK/ypSirrRau50I6w21vuQQpxaBEiQiThfECa/FBqcT2F6ZyTac="
 

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -26,7 +26,7 @@ from pyunifiprotect.data.websocket import (
     WSSubscriptionMessage,
 )
 from pyunifiprotect.utils import print_ws_stat_summary, to_js_time, utc_now
-from tests.conftest import MockDatetime, MockWebsocket
+from tests.conftest import TEST_CAMERA_EXISTS, TEST_SENSOR_EXISTS, MockDatetime, MockWebsocket
 
 PACKET_RAW = "AQEBAAAAAHR4nCXMQQrCMBBA0auUWRvIpJOm8Qbi2gNMZiZQ0NRFqIh4dwluP7z/AZa+7Q3OE7AqnCZo9ro9lbtddFRPhCayuOorOyqYXfEJXcprEqQZ55UHe+xq96u9h7HDWh9x+y+UqeZAsUrQrCFajFQWgu8PBLYjMAIBAQAAAAC2eJxVjr0KwzAMhF8leO6QOLZDOrdT126lg2PLxRA7wVYKIeTdK1PoD2jQfTodtzFcZ2DHiiUfH+xQsYw6IYFGtbyplaKRnDhE+0u7N81mSuW9LnugzxMgGLxSaCZ8u//z8xMifg4BUFuNmvS2kzY6QCqKdaaXsrNOcSN1ywfbgXGtg1JwpjSPfopkjMs4EloypK/ypSirrRau50I6w21vuQQpxaBEiQiThfECa/FBqcT2F6ZyTac="
 
@@ -373,6 +373,7 @@ async def test_ws_event_update(protect_client_no_debug: ProtectApiClient, now, c
     assert bootstrap == bootstrap_before
 
 
+@pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")
 @patch("pyunifiprotect.data.devices.utc_now")
 @pytest.mark.asyncio
 async def test_ws_emit_ring_callback(
@@ -410,6 +411,7 @@ async def test_ws_emit_ring_callback(
     protect_client.emit_message.assert_called_once()
 
 
+@pytest.mark.skipif(not TEST_SENSOR_EXISTS, reason="Missing testdata")
 @patch("pyunifiprotect.data.devices.utc_now")
 @pytest.mark.asyncio
 async def test_ws_emit_tamper_callback(
@@ -447,6 +449,7 @@ async def test_ws_emit_tamper_callback(
     protect_client.emit_message.assert_called_once()
 
 
+@pytest.mark.skipif(not TEST_SENSOR_EXISTS, reason="Missing testdata")
 @patch("pyunifiprotect.data.devices.utc_now")
 @pytest.mark.asyncio
 async def test_ws_emit_alarm_callback(

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -7,7 +7,7 @@ import base64
 from copy import deepcopy
 from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, Optional
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
@@ -377,7 +377,7 @@ async def test_ws_emit_ring_callback(
 ):
     mock_now.return_value = now
     protect_client = protect_client_no_debug
-    protect_client.emit_message = AsyncMock()  # type: ignore
+    protect_client.emit_message = Mock()  # type: ignore
 
     obj = protect_client.bootstrap.cameras[camera["id"]]
 
@@ -398,7 +398,8 @@ async def test_ws_emit_ring_callback(
     msg.data = packet.pack_frames()
 
     assert not obj.is_ringing
-    protect_client._process_ws_message(msg)
+    with patch("pyunifiprotect.data.bootstrap.utc_now", mock_now):
+        protect_client._process_ws_message(msg)
     assert obj.is_ringing
     mock_now.return_value = utc_now() + EVENT_PING_INTERVAL
     assert not obj.is_ringing
@@ -413,7 +414,7 @@ async def test_ws_emit_tamper_callback(
 ):
     mock_now.return_value = now
     protect_client = protect_client_no_debug
-    protect_client.emit_message = AsyncMock()  # type: ignore
+    protect_client.emit_message = Mock()  # type: ignore
 
     obj = protect_client.bootstrap.sensors[sensor["id"]]
 
@@ -434,7 +435,8 @@ async def test_ws_emit_tamper_callback(
     msg.data = packet.pack_frames()
 
     assert not obj.is_tampering_detected
-    protect_client._process_ws_message(msg)
+    with patch("pyunifiprotect.data.bootstrap.utc_now", mock_now):
+        protect_client._process_ws_message(msg)
     assert obj.is_tampering_detected
     mock_now.return_value = utc_now() + EVENT_PING_INTERVAL
     assert not obj.is_tampering_detected
@@ -449,7 +451,7 @@ async def test_ws_emit_alarm_callback(
 ):
     mock_now.return_value = now
     protect_client = protect_client_no_debug
-    protect_client.emit_message = AsyncMock()  # type: ignore
+    protect_client.emit_message = Mock()  # type: ignore
 
     obj = protect_client.bootstrap.sensors[sensor["id"]]
 
@@ -470,7 +472,8 @@ async def test_ws_emit_alarm_callback(
     msg.data = packet.pack_frames()
 
     assert not obj.is_alarm_detected
-    protect_client._process_ws_message(msg)
+    with patch("pyunifiprotect.data.bootstrap.utc_now", mock_now):
+        protect_client._process_ws_message(msg)
     assert obj.is_alarm_detected
     mock_now.return_value = utc_now() + EVENT_PING_INTERVAL
     assert not obj.is_alarm_detected


### PR DESCRIPTION
After testing more in my main HA install, I found some more issues. 

Issues:

* `emit_message` was not being awaited
* As a result of above ^ the triggers were very inconsistent

Changes:

* Use fixed point in future as when the event "ends". This let's look at the WS value for the 30 second cutoff, but still have the 3 second "auto-expire"
* No more datetime math for the `is_` property. 
* Improves WS reconnects in the event of a disconnect


Since I am kind of tired of making releases only to test in my prod install. I am going to directly install this branch in my prod HA and test it further before marking as read.
