### PR TITLE
Refactor Websocket code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,6 @@
         "python.testing.pytestArgs": [
             "--cov-report=xml",
             "--color=no",
-            "-n=auto",
         ],
     },
     "postCreateCommand": "cd /workspaces/pyunifiprotect && pip install -e .[dev] && unifi-protect --install-completion bash"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,7 +66,7 @@
             "request": "test",
             "console": "integratedTerminal",
             "env": {
-                "PYTEST_ADDOPTS": "--no-cov -vv"
+                "PYTEST_ADDOPTS": "-n=0 --no-cov -vv"
             }
         }
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ norecursedirs = [
     "testing_config",
     ".tox",
 ]
-addopts = "--cov=pyunifiprotect --cov-append -rP"
+addopts = "--cov=pyunifiprotect --cov-append -rP -n=auto"
 
 [tool.flake8]
 exclude = ".eggs, .git, .tox, dist"

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -104,6 +104,7 @@ class BaseApiClient:
         if self._port != 443:
             url += f":{self._port}"
 
+        url += self.ws_path
         last_update_id = self._get_last_update_id()
         if last_update_id is None:
             return url

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -400,9 +400,9 @@ class ProtectApiClient(BaseApiClient):
     _minimum_score: int
     _subscribed_models: Set[ModelType]
     _ignore_stats: bool
+    _ws_subscriptions: List[Callable[[WSSubscriptionMessage], None]]
     _bootstrap: Optional[Bootstrap] = None
     _last_update_dt: Optional[datetime] = None
-    _ws_subscriptions: List[Callable[[WSSubscriptionMessage], None]] = []
     _connection_host: Optional[Union[IPv4Address, str]] = None
 
     ignore_unadopted: bool
@@ -434,6 +434,7 @@ class ProtectApiClient(BaseApiClient):
         self._minimum_score = minimum_score
         self._subscribed_models = subscribed_models or set()
         self._ignore_stats = ignore_stats
+        self._ws_subscriptions = []
         self.ignore_unadopted = ignore_unadopted
 
         if override_connection_host:

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -71,7 +71,7 @@ class BaseApiClient:
     _websocket: Optional[Websocket] = None
 
     api_path: str = "/proxy/protect/api/"
-    ws_path: str = "/proxy/protect/ws/"
+    ws_path: str = "/proxy/protect/ws/updates"
 
     def __init__(
         self,

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -58,12 +58,6 @@ RETRY_TIMEOUT = 10
 _LOGGER = logging.getLogger(__name__)
 
 
-def _reset_connection(connection: Optional[Union[aiohttp.ClientSession, aiohttp.ClientWebSocketResponse]]) -> None:
-    if connection is not None and not connection.closed:
-        loop = asyncio.get_running_loop()
-        loop.create_task(connection.close())
-
-
 class BaseApiClient:
     _host: str
     _port: int

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -44,6 +44,7 @@ from pyunifiprotect.utils import (
     to_js_time,
     utc_now,
 )
+from pyunifiprotect.websocket import Websocket
 
 NEVER_RAN = -1000
 # how many seconds before the bootstrap is refreshed from Protect
@@ -71,16 +72,11 @@ class BaseApiClient:
     _verify_ssl: bool
     _is_authenticated: bool = False
     _last_update: float = NEVER_RAN
-    _last_websocket_check: float = NEVER_RAN
-    _last_websocket_status: bool = False
+    _last_ws_status: bool = False
     _session: Optional[aiohttp.ClientSession] = None
-    _ws_session: Optional[aiohttp.ClientSession] = None
-    _ws_connection: Optional[aiohttp.ClientWebSocketResponse] = None
-    _ws_task: Optional[asyncio.Task[None]] = None
-    _ws_raw_subscriptions: List[Callable[[aiohttp.WSMessage], None]] = []
 
     headers: Optional[Dict[str, str]] = None
-    last_update_id: Optional[UUID] = None
+    _websocket: Optional[Websocket] = None
 
     api_path: str = "/proxy/protect/api/"
     ws_path: str = "/proxy/protect/ws/"
@@ -111,14 +107,15 @@ class BaseApiClient:
         return f"https://{self._host}"
 
     @property
-    def base_ws_url(self) -> str:
+    def ws_url(self) -> str:
+        url = f"wss://{self._host}"
         if self._port != 443:
-            return f"wss://{self._host}:{self._port}"
-        return f"wss://{self._host}"
+            url += f":{self._port}"
 
-    @property
-    def is_ws_connected(self) -> bool:
-        return self._ws_connection is not None
+        last_update_id = self._get_last_update_id()
+        if last_update_id is None:
+            return url
+        return f"{url}?lastUpdateId={last_update_id}"
 
     async def get_session(self) -> aiohttp.ClientSession:
         """Gets or creates current client session"""
@@ -130,6 +127,19 @@ class BaseApiClient:
             self._session = aiohttp.ClientSession(cookie_jar=CookieJar(unsafe=True))
 
         return self._session
+
+    async def get_websocket(self) -> Websocket:
+        """Gets or creates current Websocket."""
+
+        async def _auth() -> Optional[Dict[str, str]]:
+            await self.ensure_authenticated()
+            return self.headers
+
+        if self._websocket is None:
+            self._websocket = Websocket(self.ws_url, _auth, verify=self._verify_ssl)
+            self._websocket.subscribe(self._process_ws_message)
+
+        return self._websocket
 
     async def close_session(self) -> None:
         """Closing and delets client session"""
@@ -319,123 +329,47 @@ class BaseApiClient:
 
         return self._is_authenticated
 
-    def reset_ws(self) -> None:
-        """Forcibly resets Websocket"""
+    async def connect_ws(self, force: bool) -> None:
+        """Connect to Websocket."""
 
-        if not self.is_ws_connected:
+        if force and self._websocket is not None:
+            await self._websocket.disconnect()
+            self._websocket = None
+
+        websocket = await self.get_websocket()
+        # important to make sure WS URL is always current
+        websocket.url = self.ws_url
+
+        if not websocket.is_connected:
+            self._last_ws_status = False
+            await websocket.connect()
+
+    async def disconnect_ws(self) -> None:
+        """Disconnect from Websocket."""
+
+        if self._websocket is None:
             return
+        await self._websocket.disconnect()
 
-        _LOGGER.debug("Canceling WS task...")
-        if self._ws_task is not None:
-            try:
-                self._ws_task.cancel()
-                self._ws_task = None
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Could not cancel WS task")
+    def check_ws(self) -> bool:
+        """Checks current state of Websocket."""
 
-        if self._ws_task is None:
-            _reset_connection(self._ws_connection)
-            self._ws_connection = None
-            if self._ws_session is not None:
-                _LOGGER.debug("Reseting WS session...")
-            _reset_connection(self._ws_session)
-            self._ws_connection = None
-
-    async def async_connect_ws(self) -> None:
-        """Connect the websocket."""
-
-        # do not try to connect if already connected or connect scheduled
-        if self.is_ws_connected or self._ws_task is not None:
-            return
-
-        self.reset_ws()
-        _LOGGER.debug("Scheduling WS connect...")
-        self._ws_task = asyncio.create_task(self._setup_websocket())
-
-    async def async_disconnect_ws(self) -> None:
-        """Disconnect the websocket."""
-
-        if self._ws_connection is None:
-            return
-
-        await self._ws_connection.close()
-        self.reset_ws()
-
-    async def _message_loop(self, msg: aiohttp.WSMessage) -> bool:
-        for sub in self._ws_raw_subscriptions:
-            sub(msg)
-
-        if msg.type == aiohttp.WSMsgType.BINARY:
-            try:
-                self._process_ws_message(msg)
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Error processing websocket message")
-        elif msg.type == aiohttp.WSMsgType.ERROR:
-            _LOGGER.exception("Error from Websocket: %s", msg.data)
+        if self._websocket is None:
             return False
 
-        return True
-
-    async def _setup_websocket(self) -> None:
-        _LOGGER.debug("Setting up WS")
-        await self.ensure_authenticated()
-
-        url = urljoin(f"{self.base_ws_url}{self.ws_path}", "updates")
-        if self.last_update_id:
-            url += f"?lastUpdateId={self.last_update_id}"
-
-        if not self._ws_session:
-            self._ws_session = aiohttp.ClientSession()
-        _LOGGER.debug("WS connecting to: %s", url)
-
-        self._ws_connection = await self._ws_session.ws_connect(url, ssl=self._verify_ssl, headers=self.headers)
-        try:
-            async for msg in self._ws_connection:
-                if not await self._message_loop(msg):
-                    break
-        finally:
-            _LOGGER.debug("websocket disconnected")
-            self.reset_ws()
-
-    def subscribe_raw_websocket(self, ws_callback: Callable[[aiohttp.WSMessage], None]) -> Callable[[], None]:
-        """
-        Subscribe to raw websocket messages.
-
-        Returns a callback that will unsubscribe.
-        """
-
-        def _unsub_ws_callback() -> None:
-            self._ws_raw_subscriptions.remove(ws_callback)
-
-        _LOGGER.debug("Adding subscription: %s", ws_callback)
-        self._ws_raw_subscriptions.append(ws_callback)
-        return _unsub_ws_callback
-
-    async def check_ws(self) -> bool:
-        now = time.monotonic()
-
-        first_check = self._last_websocket_check == NEVER_RAN
-        if now - self._last_websocket_check > WEBSOCKET_CHECK_INTERVAL:
-            _LOGGER.debug("Checking websocket")
-            self._last_websocket_check = now
-            await self.async_connect_ws()
-
-        # log if no active WS
-        if not self.is_ws_connected and not first_check:
+        if not self._websocket.is_connected:
             log = _LOGGER.debug
-            # but only warn if a reconnect attempt was made
-            if self._last_websocket_status:
+            if self._last_ws_status:
                 log = _LOGGER.warning
             log("Websocket connection not active, failing back to polling")
 
-        new_status = self.is_ws_connected or self._last_websocket_check == now
-        if not self._last_websocket_status and new_status:
-            _LOGGER.info("Websocket connection successfully connected")
-
-        self._last_websocket_status = new_status
-        return self._last_websocket_status
+        self._last_ws_status = self._websocket.is_connected
+        return self._last_ws_status
 
     def _process_ws_message(self, msg: aiohttp.WSMessage) -> None:
+        raise NotImplementedError()
+
+    def _get_last_update_id(self) -> Optional[UUID]:
         raise NotImplementedError()
 
 
@@ -560,10 +494,8 @@ class ProtectApiClient(BaseApiClient):
         now_dt = utc_now()
         max_event_dt = now_dt - timedelta(hours=24)
         if force:
-            self.reset_ws()
             self._last_update = NEVER_RAN
             self._last_update_dt = max_event_dt
-            self._last_websocket_check = NEVER_RAN
 
         bootstrap_updated = False
         if self._bootstrap is None or now - self._last_update > DEVICE_UPDATE_INTERVAL:
@@ -572,7 +504,8 @@ class ProtectApiClient(BaseApiClient):
             self._last_update_dt = now_dt
             self._bootstrap = await self.get_bootstrap()
 
-        active_ws = await self.check_ws()
+        await self.connect_ws(force)
+        active_ws = self.check_ws()
         if not bootstrap_updated and active_ws:
             # If the websocket is connected/connecting
             # we do not need to get events
@@ -594,11 +527,19 @@ class ProtectApiClient(BaseApiClient):
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Exception while running subscription handler")
 
+    def _get_last_update_id(self) -> Optional[UUID]:
+        if self._bootstrap is None:
+            return None
+        return self._bootstrap.last_update_id
+
     def _process_ws_message(self, msg: aiohttp.WSMessage) -> None:
         packet = WSPacket(msg.data)
         processed_message = self.bootstrap.process_ws_packet(
             packet, models=self._subscribed_models, ignore_stats=self._ignore_stats
         )
+        # update websocket URL after every message to ensure the latest last_update_id
+        if self._websocket is not None:
+            self._websocket.url = self.ws_url
 
         if processed_message is None:
             return

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -57,6 +57,12 @@ RETRY_TIMEOUT = 10
 _LOGGER = logging.getLogger(__name__)
 
 
+def _reset_connection(connection: Optional[Union[aiohttp.ClientSession, aiohttp.ClientWebSocketResponse]]) -> None:
+    if connection is not None and not connection.closed:
+        loop = asyncio.get_running_loop()
+        loop.create_task(connection.close())
+
+
 class BaseApiClient:
     _host: str
     _port: int
@@ -313,13 +319,6 @@ class BaseApiClient:
 
         return self._is_authenticated
 
-    def _reset_connection(
-        self, connection: Optional[Union[aiohttp.ClientSession, aiohttp.ClientWebSocketResponse]]
-    ) -> None:
-        if connection is not None and not connection.closed:
-            loop = asyncio.get_running_loop()
-            loop.create_task(connection.close())
-
     def reset_ws(self) -> None:
         """Forcibly resets Websocket"""
 
@@ -335,11 +334,11 @@ class BaseApiClient:
                 _LOGGER.exception("Could not cancel WS task")
 
         if self._ws_task is None:
-            self._reset_connection(self._ws_connection)
+            _reset_connection(self._ws_connection)
             self._ws_connection = None
             if self._ws_session is not None:
                 _LOGGER.debug("Reseting WS session...")
-            self._reset_connection(self._ws_session)
+            _reset_connection(self._ws_session)
             self._ws_connection = None
 
     async def async_connect_ws(self) -> None:

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -49,8 +49,6 @@ from pyunifiprotect.websocket import Websocket
 NEVER_RAN = -1000
 # how many seconds before the bootstrap is refreshed from Protect
 DEVICE_UPDATE_INTERVAL = 900
-# how many seconds before before we check for an active WS connection
-WEBSOCKET_CHECK_INTERVAL = 30
 # retry timeout for thumbnails/heatmaps
 RETRY_TIMEOUT = 10
 

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -323,7 +323,7 @@ class BaseApiClient:
 
         return self._is_authenticated
 
-    async def connect_ws(self, force: bool) -> None:
+    async def async_connect_ws(self, force: bool) -> None:
         """Connect to Websocket."""
 
         if force and self._websocket is not None:
@@ -338,7 +338,7 @@ class BaseApiClient:
             self._last_ws_status = False
             await websocket.connect()
 
-    async def disconnect_ws(self) -> None:
+    async def async_disconnect_ws(self) -> None:
         """Disconnect from Websocket."""
 
         if self._websocket is None:
@@ -498,7 +498,7 @@ class ProtectApiClient(BaseApiClient):
             self._last_update_dt = now_dt
             self._bootstrap = await self.get_bootstrap()
 
-        await self.connect_ws(force)
+        await self.async_connect_ws(force)
         active_ws = self.check_ws()
         if not bootstrap_updated and active_ws:
             # If the websocket is connected/connecting
@@ -527,6 +527,7 @@ class ProtectApiClient(BaseApiClient):
         return self._bootstrap.last_update_id
 
     def _process_ws_message(self, msg: aiohttp.WSMessage) -> None:
+        _LOGGER.debug("Processing WS message...")
         packet = WSPacket(msg.data)
         processed_message = self.bootstrap.process_ws_packet(
             packet, models=self._subscribed_models, ignore_stats=self._ignore_stats

--- a/pyunifiprotect/test_util/__init__.py
+++ b/pyunifiprotect/test_util/__init__.py
@@ -108,7 +108,8 @@ class SampleDataGenerator:
     async def async_generate(self, close_session: bool = True) -> None:
         self.log(f"Output folder: {self.output_folder}")
         self.output_folder.mkdir(parents=True, exist_ok=True)
-        self.client.subscribe_raw_websocket(self._handle_ws_message)
+        websocket = await self.client.get_websocket()
+        websocket.subscribe(self._handle_ws_message)
 
         self.log("Updating devices...")
         await self.client.update(True)
@@ -173,7 +174,7 @@ class SampleDataGenerator:
             await asyncio.sleep(self.wait_time)
 
         self._record_listen_for_events = False
-        await self.client.async_disconnect_ws()
+        await self.client.disconnect_ws()
         await self.write_json_file("sample_ws_messages", self._record_ws_messages, anonymize=False)
 
     @overload

--- a/pyunifiprotect/test_util/__init__.py
+++ b/pyunifiprotect/test_util/__init__.py
@@ -174,7 +174,7 @@ class SampleDataGenerator:
             await asyncio.sleep(self.wait_time)
 
         self._record_listen_for_events = False
-        await self.client.disconnect_ws()
+        await self.client.async_disconnect_ws()
         await self.write_json_file("sample_ws_messages", self._record_ws_messages, anonymize=False)
 
     @overload

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -64,6 +64,7 @@ class Websocket:
     async def _websocket_loop(self) -> None:
         _LOGGER.debug("Connecting WS to %s", self.url)
         self._headers = await self._auth()
+        _LOGGER.debug(self._headers)
 
         session = self._get_session()
         self._ws_connection = await session.ws_connect(self.url, ssl=self.verify, headers=self._headers)
@@ -117,10 +118,14 @@ class Websocket:
         connect_timeout = time.monotonic() + self.timeout_interval
         # wait for message to ensure it is connected
         while time.monotonic() < connect_timeout and start_time == self._timeout:
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(1)
+
+        if self._ws_connection and time.monotonic() > connect_timeout:
+            await self.disconnect()
         if self._ws_connection is None:
             _LOGGER.warning("Failed to connect to Websocket")
             return False
+
         _LOGGER.info("Connected to Websocket successfully")
         return True
 

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -115,10 +115,12 @@ class Websocket:
         asyncio.create_task(self._websocket_loop())
         start_time = self._timeout
         connect_timeout = time.monotonic() + self.timeout_interval
+        was_connected = False
         # wait for message to ensure it is connected
         while time.monotonic() < connect_timeout and start_time == self._timeout:
-            if not self.is_connected:
+            if was_connected and not self.is_connected:
                 break
+            was_connected = self.is_connected
             await asyncio.sleep(1)
 
         if self.is_connected and time.monotonic() > connect_timeout:

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -14,7 +14,7 @@ class Websocket:
     url: str
     verify: bool
     timeout_interval: int
-    reconnect_wait: int
+    backoff: int
     _auth: CALLBACK_TYPE
     _timeout: float
     _ws_subscriptions: List[Callable[[WSMessage], None]]
@@ -28,12 +28,12 @@ class Websocket:
         url: str,
         auth_callback: CALLBACK_TYPE,
         timeout: int = 30,
-        reconnect_wait: int = 10,
+        backoff: int = 10,
         verify: bool = True,
     ) -> None:
         self.url = url
         self.timeout_interval = timeout
-        self.reconnect_wait = reconnect_wait
+        self.backoff = backoff
         self.verify = verify
         self._auth = auth_callback  # type: ignore
         self._timeout = time.monotonic()
@@ -144,7 +144,7 @@ class Websocket:
 
         _LOGGER.debug("Reconnecting websocket...")
         await self.disconnect()
-        await asyncio.sleep(self.reconnect_wait)
+        await asyncio.sleep(self.backoff)
         return await self.connect()
 
     def subscribe(self, ws_callback: Callable[[WSMessage], None]) -> Callable[[], None]:

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -1,0 +1,138 @@
+import asyncio
+from collections.abc import Callable
+import logging
+from typing import Any, Coroutine, Dict, List, Optional
+
+from aiohttp import ClientSession, ClientWebSocketResponse, WSMessage, WSMsgType
+
+_LOGGER = logging.getLogger(__name__)
+CALLBACK_TYPE = Callable[..., Coroutine[Any, Any, Optional[Dict[str, str]]]]
+
+
+class Websocket:
+    url: str
+    verify: bool
+    timeout: int
+    reconnect_wait: int
+    _auth: CALLBACK_TYPE
+
+    _headers: Optional[Dict[str, str]] = None
+    _timer_task: Optional[asyncio.TimerHandle] = None
+    _ws_task: Optional[asyncio.Task[None]] = None
+    _ws_subscriptions: List[Callable[[WSMessage], None]] = []
+    _ws_connection: Optional[ClientWebSocketResponse] = None
+
+    def __init__(
+        self,
+        url: str,
+        auth_callback: CALLBACK_TYPE,
+        timeout: int = 30,
+        reconnect_wait: int = 10,
+        verify: bool = True,
+    ) -> None:
+        self.url = url
+        self.timeout = timeout
+        self.reconnect_wait = reconnect_wait
+        self.verify = verify
+        self._auth = auth_callback  # type: ignore
+
+    @property
+    def is_connected(self) -> bool:
+        """Is Websocket connected"""
+        return self._ws_connection is not None
+
+    def _get_session(self) -> ClientSession:  # pylint: disable=no-self-use
+        # for testing, to make easier to mock
+        return ClientSession()
+
+    async def _process_message(self, msg: WSMessage) -> bool:
+        if msg.type == WSMsgType.ERROR:
+            _LOGGER.exception("Error from Websocket: %s", msg.data)
+            return False
+
+        for sub in self._ws_subscriptions:
+            try:
+                sub(msg)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Error processing websocket message")
+
+        return True
+
+    async def _websocket_loop(self) -> None:
+        _LOGGER.debug("Connecting WS to %s", self.url)
+        self._headers = await self._auth()
+
+        session = self._get_session()
+        self._ws_connection = await session.ws_connect(self.url, ssl=self.verify, headers=self._headers)
+        try:
+            await self._reset_timeout()
+            async for msg in self._ws_connection:
+                if not await self._process_message(msg):
+                    break
+                await self._reset_timeout()
+        finally:
+            _LOGGER.debug("Websocket disconnected")
+            self._cancel_timeout()
+            if not self._ws_connection.closed:
+                await self._ws_connection.close()
+                self._ws_connection = None
+            if not session.closed:
+                await session.close()
+
+    def _cancel_timeout(self) -> None:
+        if self._timer_task:
+            self._timer_task.cancel()
+
+    async def _timeout(self) -> None:
+        _LOGGER.debug("WS timed out")
+        if not await self.reconnect():
+            await self._timeout()
+
+    async def _reset_timeout(self) -> None:
+        _LOGGER.debug("WS timeout reset")
+        self._cancel_timeout()
+        loop = asyncio.get_running_loop()
+        self._timer_task = loop.call_later(self.timeout, lambda: asyncio.create_task(self._timeout()))
+
+    async def connect(self) -> bool:
+        """Connect the websocket."""
+
+        _LOGGER.debug("Scheduling WS connect...")
+        self._ws_task = asyncio.create_task(self._websocket_loop())
+        await asyncio.sleep(1)
+        if self._ws_connection is None:
+            _LOGGER.warning("Failed to connect to Websocket")
+            self._ws_task = None
+            return False
+        _LOGGER.info("Connected to Websocket successfully")
+        return True
+
+    async def disconnect(self) -> None:
+        """Disconnect the websocket."""
+
+        _LOGGER.debug("Disconnecting websocket...")
+        if self._ws_connection is None:
+            return
+        await self._ws_connection.close()
+
+    async def reconnect(self) -> bool:
+        """Reconnect the websocket."""
+
+        _LOGGER.debug("Reconnecting websocket...")
+        await self.disconnect()
+        await asyncio.sleep(self.reconnect_wait)
+        return await self.connect()
+
+    def subscribe(self, ws_callback: Callable[[WSMessage], None]) -> Callable[[], None]:
+        """
+        Subscribe to raw websocket messages.
+
+        Returns a callback that will unsubscribe.
+        """
+
+        def _unsub_ws_callback() -> None:
+            self._ws_subscriptions.remove(ws_callback)
+
+        _LOGGER.debug("Adding subscription: %s", ws_callback)
+        self._ws_subscriptions.append(ws_callback)
+        return _unsub_ws_callback

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -91,9 +91,11 @@ class Websocket:
             if now > self._timeout:
                 _LOGGER.debug("WS timed out")
                 if not await self.reconnect():
-                    _LOGGER.debug("Could not reconnect")
+                    _LOGGER.debug("WS could not reconnect")
                     continue
-            await asyncio.sleep(self._timeout - now)
+            sleep_time = self._timeout - now
+            _LOGGER.debug("WS Timeout loop sleep %s", sleep_time)
+            await asyncio.sleep(sleep_time)
 
     async def _reset_timeout(self) -> None:
         _LOGGER.debug("WS timeout reset")

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -18,7 +18,6 @@ class Websocket:
 
     _headers: Optional[Dict[str, str]] = None
     _timer_task: Optional[asyncio.TimerHandle] = None
-    _ws_task: Optional[asyncio.Task[None]] = None
     _ws_subscriptions: List[Callable[[WSMessage], None]] = []
     _ws_connection: Optional[ClientWebSocketResponse] = None
 
@@ -98,11 +97,10 @@ class Websocket:
         """Connect the websocket."""
 
         _LOGGER.debug("Scheduling WS connect...")
-        self._ws_task = asyncio.create_task(self._websocket_loop())
+        asyncio.create_task(self._websocket_loop())
         await asyncio.sleep(1)
         if self._ws_connection is None:
             _LOGGER.warning("Failed to connect to Websocket")
-            self._ws_task = None
             return False
         _LOGGER.info("Connected to Websocket successfully")
         return True

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -64,7 +64,6 @@ class Websocket:
     async def _websocket_loop(self) -> None:
         _LOGGER.debug("Connecting WS to %s", self.url)
         self._headers = await self._auth()
-        _LOGGER.debug(self._headers)
 
         session = self._get_session()
         self._ws_connection = await session.ws_connect(self.url, ssl=self.verify, headers=self._headers)
@@ -136,6 +135,7 @@ class Websocket:
         if self._ws_connection is None:
             return
         await self._ws_connection.close()
+        self._ws_connection = None
 
     async def reconnect(self) -> bool:
         """Reconnect the websocket."""

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -17,10 +17,10 @@ class Websocket:
     reconnect_wait: int
     _auth: CALLBACK_TYPE
     _timeout: float
+    _ws_subscriptions: List[Callable[[WSMessage], None]]
 
     _headers: Optional[Dict[str, str]] = None
     _timer_task: Optional[asyncio.Task[None]] = None
-    _ws_subscriptions: List[Callable[[WSMessage], None]] = []
     _ws_connection: Optional[ClientWebSocketResponse] = None
 
     def __init__(
@@ -37,6 +37,7 @@ class Websocket:
         self.verify = verify
         self._auth = auth_callback  # type: ignore
         self._timeout = time.monotonic()
+        self._ws_subscriptions = []
 
     @property
     def is_connected(self) -> bool:

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -77,9 +77,9 @@ class Websocket:
             self._cancel_timeout()
             if not self._ws_connection.closed:
                 await self._ws_connection.close()
-                self._ws_connection = None
             if not session.closed:
                 await session.close()
+            self._ws_connection = None
 
     async def _do_timeout(self) -> bool:
         _LOGGER.debug("WS timed out")
@@ -117,9 +117,11 @@ class Websocket:
         connect_timeout = time.monotonic() + self.timeout_interval
         # wait for message to ensure it is connected
         while time.monotonic() < connect_timeout and start_time == self._timeout:
+            if not self.is_connected:
+                break
             await asyncio.sleep(1)
 
-        if self._ws_connection and time.monotonic() > connect_timeout:
+        if self.is_connected and time.monotonic() > connect_timeout:
             await self.disconnect()
         if self._ws_connection is None:
             _LOGGER.warning("Failed to connect to Websocket")

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -52,6 +52,7 @@ class Websocket:
             _LOGGER.exception("Error from Websocket: %s", msg.data)
             return False
 
+        _LOGGER.debug("Recieved WS message. Sending to %s subscribers...", len(self._ws_subscriptions))
         for sub in self._ws_subscriptions:
             try:
                 sub(msg)

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -1,7 +1,6 @@
 import asyncio
 from collections.abc import Callable
 import logging
-from socket import timeout
 import time
 from typing import Any, Coroutine, Dict, List, Optional
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,10 @@ class SimpleMockWebsocket:
     def __init__(self):
         self.events = []
 
+    @property
+    def closed(self):
+        return self.is_closed
+
     async def close(self):
         self.is_closed = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import base64
-import contextlib
 from datetime import datetime, timezone
 import json
 import os
@@ -170,25 +169,23 @@ def ensure_debug():
 
 
 async def setup_client(client: ProtectApiClient, websocket: SimpleMockWebsocket):
+    mock_cs = Mock()
+    mock_session = AsyncMock()
+    mock_session.ws_connect = AsyncMock(return_value=websocket)
+    mock_cs.return_value = mock_session
+
+    ws = await client.get_websocket()
+    ws._get_session = mock_cs  # type: ignore
     client.api_request = AsyncMock(side_effect=mock_api_request)  # type: ignore
     client.api_request_raw = AsyncMock(side_effect=mock_api_request_raw)  # type: ignore
     client.ensure_authenticated = AsyncMock()  # type: ignore
-    client._ws_session = AsyncMock()
-    client._ws_session.ws_connect = AsyncMock(return_value=websocket)
-    await client.update(True)
+    await client.update()
 
     return client
 
 
 async def cleanup_client(client: ProtectApiClient):
-    await client.async_disconnect_ws()
-    with contextlib.suppress(asyncio.CancelledError):
-        if client._ws_task is not None:
-            client._ws_task.cancel()
-
-            # empty out websockets
-            await client._ws_task
-
+    await client.disconnect_ws()
     await client.close_session()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,7 +185,7 @@ async def setup_client(client: ProtectApiClient, websocket: SimpleMockWebsocket)
 
 
 async def cleanup_client(client: ProtectApiClient):
-    await client.disconnect_ws()
+    await client.async_disconnect_ws()
     await client.close_session()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,13 +168,14 @@ def ensure_debug():
     set_debug()
 
 
-async def setup_client(client: ProtectApiClient, websocket: SimpleMockWebsocket):
+async def setup_client(client: ProtectApiClient, websocket: SimpleMockWebsocket, timeout: int = 0):
     mock_cs = Mock()
     mock_session = AsyncMock()
     mock_session.ws_connect = AsyncMock(return_value=websocket)
     mock_cs.return_value = mock_session
 
     ws = await client.get_websocket()
+    ws.timeout_interval = timeout
     ws._get_session = mock_cs  # type: ignore
     client.api_request = AsyncMock(side_effect=mock_api_request)  # type: ignore
     client.api_request_raw = AsyncMock(side_effect=mock_api_request_raw)  # type: ignore
@@ -213,7 +214,7 @@ async def protect_client_ws():
     set_no_debug()
 
     client = ProtectApiClient("127.0.0.1", 0, "username", "password")
-    yield await setup_client(client, MockWebsocket())
+    yield await setup_client(client, MockWebsocket(), timeout=30)
     await cleanup_client(client)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -137,13 +137,15 @@ async def check_bootstrap(bootstrap: Bootstrap):
 
 
 def test_base_url(protect_client: ProtectApiClient):
+    arg = f"?lastUpdateId={protect_client.bootstrap.last_update_id}"
+
     assert protect_client.base_url == "https://127.0.0.1:0"
-    assert protect_client.base_ws_url == "wss://127.0.0.1:0"
+    assert protect_client.ws_url == f"wss://127.0.0.1:0{arg}"
 
     protect_client._port = 443
 
     assert protect_client.base_url == "https://127.0.0.1"
-    assert protect_client.base_ws_url == "wss://127.0.0.1"
+    assert protect_client.ws_url == f"wss://127.0.0.1{arg}"
 
 
 def test_api_client_creation():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -137,7 +137,7 @@ async def check_bootstrap(bootstrap: Bootstrap):
 
 
 def test_base_url(protect_client: ProtectApiClient):
-    arg = f"?lastUpdateId={protect_client.bootstrap.last_update_id}"
+    arg = f"{protect_client.ws_path}?lastUpdateId={protect_client.bootstrap.last_update_id}"
 
     assert protect_client.base_url == "https://127.0.0.1:0"
     assert protect_client.ws_url == f"wss://127.0.0.1:0{arg}"

--- a/tests/test_api_polling.py
+++ b/tests/test_api_polling.py
@@ -1,4 +1,5 @@
 """Tests for pyunifiprotect.unifi_protect_server."""
+# pylint: disable=protected-access
 
 from datetime import timedelta
 from unittest.mock import patch
@@ -6,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from pyunifiprotect import ProtectApiClient
+from pyunifiprotect.api import NEVER_RAN
 from pyunifiprotect.data import EventType
 from pyunifiprotect.utils import to_js_time
 from tests.conftest import MockDatetime
@@ -63,6 +65,7 @@ async def test_process_events_ring(protect_client: ProtectApiClient, now, camera
 
     setattr(protect_client, "get_events_raw", get_events)
 
+    protect_client._last_update = NEVER_RAN
     await protect_client.update()
 
     bootstrap = protect_client.bootstrap.unifi_dict()
@@ -70,6 +73,8 @@ async def test_process_events_ring(protect_client: ProtectApiClient, now, camera
 
     event = camera.last_ring_event
     camera_before.last_ring_event_id = None
+    camera_before.last_motion_event_id = None
+    camera_before.last_smart_detect_event_id = None
     camera.last_ring_event_id = None
 
     assert bootstrap == bootstrap_before
@@ -113,6 +118,7 @@ async def test_process_events_motion(protect_client: ProtectApiClient, now, came
 
     setattr(protect_client, "get_events_raw", get_events)
 
+    protect_client._last_update = NEVER_RAN
     await protect_client.update()
 
     camera_before.is_motion_detected = False
@@ -122,6 +128,8 @@ async def test_process_events_motion(protect_client: ProtectApiClient, now, came
     event = camera.last_motion_event
     camera.last_motion_event_id = None
     camera_before.last_motion_event_id = None
+    camera_before.last_ring_event_id = None
+    camera_before.last_smart_detect_event_id = None
 
     assert bootstrap == bootstrap_before
     assert camera.dict() == camera_before.dict()
@@ -165,6 +173,7 @@ async def test_process_events_smart(protect_client: ProtectApiClient, now, camer
 
     setattr(protect_client, "get_events_raw", get_events)
 
+    protect_client._last_update = NEVER_RAN
     await protect_client.update()
 
     bootstrap = protect_client.bootstrap.unifi_dict()
@@ -173,6 +182,8 @@ async def test_process_events_smart(protect_client: ProtectApiClient, now, camer
     smart_event = camera.last_smart_detect_event
     camera.last_smart_detect_event_id = None
     camera_before.last_smart_detect_event_id = None
+    camera_before.last_motion_event_id = None
+    camera_before.last_ring_event_id = None
 
     assert bootstrap == bootstrap_before
     assert camera.dict() == camera_before.dict()

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -7,15 +7,13 @@ import base64
 from copy import deepcopy
 from datetime import datetime, timedelta
 import logging
-import time
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.api import NEVER_RAN, WEBSOCKET_CHECK_INTERVAL
 from pyunifiprotect.data import EventType, WSPacket
 from pyunifiprotect.data.base import ProtectModel
 from pyunifiprotect.data.devices import EVENT_PING_INTERVAL, Camera
@@ -85,16 +83,12 @@ async def test_ws_all(
     # bypass pydantic checks
     object.__setattr__(protect_client.bootstrap, "process_ws_packet", benchmark_process_ws_packet)
 
-    # wait for ws connection
-    for _ in range(60):
-        if protect_client.is_ws_connected:
-            break
-        await asyncio.sleep(0.5)
+    websocket = await protect_client.get_websocket()
 
-    ws_connect: Optional[MockWebsocket] = protect_client._ws_connection  # type: ignore
+    ws_connect: Optional[MockWebsocket] = websocket._ws_connection  # type: ignore
     assert ws_connect is not None
 
-    while protect_client.is_ws_connected:
+    while websocket.is_connected:
         await asyncio.sleep(0.1)
 
     assert ws_connect.count == len(ws_messages)
@@ -132,16 +126,12 @@ async def test_ws_filtered(protect_client_ws: ProtectApiClient, benchmark: Bench
     # bypass pydantic checks
     object.__setattr__(protect_client.bootstrap, "process_ws_packet", benchmark_process_ws_packet)
 
-    # wait for ws connection
-    for _ in range(60):
-        if protect_client.is_ws_connected:
-            break
-        await asyncio.sleep(0.5)
+    websocket = await protect_client.get_websocket()
 
-    ws_connect: Optional[MockWebsocket] = protect_client._ws_connection  # type: ignore
+    ws_connect: Optional[MockWebsocket] = websocket._ws_connection  # type: ignore
     assert ws_connect is not None
 
-    while protect_client.is_ws_connected:
+    while websocket.is_connected:
         await asyncio.sleep(0.1)
 
     print_ws_stat_summary(protect_client.bootstrap.ws_stats)
@@ -493,51 +483,44 @@ async def test_ws_emit_alarm_callback(
 
 
 @pytest.mark.asyncio
-async def test_check_ws_initial(protect_client: ProtectApiClient, caplog: pytest.LogCaptureFixture):
+async def test_check_ws_connected(protect_client_ws: ProtectApiClient, caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.DEBUG)
 
-    protect_client._last_websocket_check = NEVER_RAN
-    protect_client.reset_ws()
-
-    active_ws = await protect_client.check_ws()
+    active_ws = protect_client_ws.check_ws()
 
     assert active_ws is True
-    assert ["Checking websocket", "Scheduling WS connect..."] == [rec.message for rec in caplog.records]
+
+    expected_logs: List[str] = []
+    assert expected_logs == [rec.message for rec in caplog.records]
+
+
+@pytest.mark.asyncio
+async def test_check_ws_no_ws_initial(protect_client: ProtectApiClient, caplog: pytest.LogCaptureFixture):
+    caplog.set_level(logging.DEBUG)
+
+    await protect_client.disconnect_ws()
+    protect_client._last_ws_status = True
+
+    active_ws = protect_client.check_ws()
+
+    assert active_ws is False
+
+    expected_logs = ["Disconnecting websocket...", "Websocket connection not active, failing back to polling"]
+    assert expected_logs == [rec.message for rec in caplog.records]
+    assert caplog.records[1].levelname == "WARNING"
 
 
 @pytest.mark.asyncio
 async def test_check_ws_no_ws(protect_client: ProtectApiClient, caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.DEBUG)
 
-    protect_client._last_websocket_status = True
-    protect_client._last_websocket_check = time.monotonic()
-    protect_client.reset_ws()
+    await protect_client.disconnect_ws()
+    protect_client._last_ws_status = False
 
-    active_ws = await protect_client.check_ws()
+    active_ws = protect_client.check_ws()
 
     assert active_ws is False
 
-    expected_logs = ["Websocket connection not active, failing back to polling"]
-    assert expected_logs == [rec.message for rec in caplog.records]
-    assert caplog.records[0].levelname == "WARNING"
-
-
-@pytest.mark.asyncio
-async def test_check_ws_reconnect(protect_client: ProtectApiClient, caplog: pytest.LogCaptureFixture):
-    caplog.set_level(logging.DEBUG)
-
-    protect_client._last_websocket_status = False
-    protect_client._last_websocket_check = time.monotonic() - WEBSOCKET_CHECK_INTERVAL - 1
-    protect_client.reset_ws()
-
-    active_ws = await protect_client.check_ws()
-
-    assert active_ws is True
-    expected_logs = [
-        "Checking websocket",
-        "Scheduling WS connect...",
-        "Websocket connection not active, failing back to polling",
-        "Websocket connection successfully connected",
-    ]
+    expected_logs = ["Disconnecting websocket...", "Websocket connection not active, failing back to polling"]
     assert expected_logs == [rec.message for rec in caplog.records]
     assert caplog.records[1].levelname == "DEBUG"

--- a/tests/test_api_ws.py
+++ b/tests/test_api_ws.py
@@ -498,7 +498,7 @@ async def test_check_ws_connected(protect_client_ws: ProtectApiClient, caplog: p
 async def test_check_ws_no_ws_initial(protect_client: ProtectApiClient, caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.DEBUG)
 
-    await protect_client.disconnect_ws()
+    await protect_client.async_disconnect_ws()
     protect_client._last_ws_status = True
 
     active_ws = protect_client.check_ws()
@@ -514,7 +514,7 @@ async def test_check_ws_no_ws_initial(protect_client: ProtectApiClient, caplog: 
 async def test_check_ws_no_ws(protect_client: ProtectApiClient, caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.DEBUG)
 
-    await protect_client.disconnect_ws()
+    await protect_client.async_disconnect_ws()
     protect_client._last_ws_status = False
 
     active_ws = protect_client.check_ws()


### PR DESCRIPTION
This PR will be a breaking change and need a major version bump (3.0) as it changes a number of public access variables on `ProtectApiClient`. Even if they essentially still function the same. 

Completely refactors and redesigns Websocket code:

* All Websocket code is not pulled out into a new Websocket class
* Adds timeout to handle Websocket connection getting "stuck"
* Decreases reconnect time to 10 seconds
* Simplifies async logic: WS task and WS session are no longer tracked on the class level. The disappear as soon as they are no longer relevant.
* Simplifies `last_update_id` and ensures it is always updated for future reconnects

Unrelated: Fixes python-xdist running with using "run tests", but _not_ running when you "debug tests".