### PR TITLE
Switch to floats for camera zone coords

### DIFF
--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -43,7 +43,6 @@ from pyunifiprotect.stream import TalkbackStream
 from pyunifiprotect.utils import (
     from_js_time,
     process_datetime,
-    round_decimal,
     serialize_point,
     to_js_time,
     utc_now,
@@ -526,7 +525,7 @@ class CameraZone(ProtectBaseObject):
     def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         data = super().unifi_dict_to_dict(data)
         if "points" in data and isinstance(data["points"], Iterable):
-            data["points"] = [(round_decimal(p[0], 4), round_decimal(p[1], 4)) for p in data["points"]]
+            data["points"] = [(p[0], p[1]) for p in data["points"]]
 
         return data
 

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -4,7 +4,7 @@ import enum
 from typing import Any, Dict, List, Literal, Optional, TypeVar, Union
 
 from packaging.version import Version as BaseVersion
-from pydantic import ConstrainedDecimal, ConstrainedInt
+from pydantic import ConstrainedInt
 from pydantic.color import Color as BaseColor
 from pydantic.types import ConstrainedFloat, ConstrainedStr
 
@@ -305,11 +305,9 @@ class WDRLevel(ConstrainedInt):
     le = 3
 
 
-class Percent(ConstrainedDecimal):
+class Percent(ConstrainedFloat):
     ge = 0
     le = 1
-    max_digits = 4
-    decimal_places = 3
 
 
 CoordType = Union[Percent, int, float]

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -11,6 +11,7 @@ from inspect import isclass
 from ipaddress import AddressValueError, IPv4Address
 import json
 import logging
+import math
 import os
 from pathlib import Path
 import re
@@ -46,7 +47,6 @@ if TYPE_CHECKING:
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 DEBUG_ENV = "UFP_DEBUG"
 PROGRESS_CALLABLE = Callable[[int, str], Coroutine[Any, Any, None]]
-DECIMAL_EVEN = (Decimal(1), Decimal(0))
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -220,12 +220,12 @@ def serialize_coord(coord: CoordType) -> Union[int, float]:
     """Serializes UFP zone coordinate"""
     from pyunifiprotect.data import Percent  # pylint: disable=import-outside-toplevel
 
-    if not isinstance(coord, (Percent, Decimal)):
+    if not isinstance(coord, Percent):
         return coord
 
-    if coord in (Decimal(1), Decimal(0)):
+    if math.isclose(coord, 0) or math.isclose(coord, 1):
         return int(coord)
-    return float(coord)
+    return coord
 
 
 def serialize_point(point: Tuple[CoordType, CoordType]) -> List[Union[int, float]]:
@@ -243,18 +243,6 @@ def serialize_list(items: Iterable[Any]) -> List[Any]:
         new_items.append(serialize_unifi_obj(item))
 
     return new_items
-
-
-def round_decimal(num: Union[Decimal, int, float], digits: int) -> Decimal:
-    """Rounds a decimal to a set precision"""
-
-    if isinstance(num, Decimal):
-        return num
-
-    unrounded = Decimal(num)
-    if unrounded in DECIMAL_EVEN:
-        return unrounded
-    return Decimal(str(round(num, digits)))
 
 
 def ip_from_host(host: str) -> IPv4Address:


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/70257.

I tried to use decimals for camera zone coords, but it has really been proving difficult and not worth it for interop with UniFi Protect since it uses floats. This just removes all of the attempts at decimals and always uses floats to match UniFi Protect.

Technically a breaking change, but I will only do a minor version bump (3.4.0) for it since they are still "number-like" types and will likely not break any downstream code.