### PR TITLE
Require newer version of typer to ensure click compatbility

### DIFF
--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-from ast import Import
 
+from ast import Import
 import asyncio
 from collections import Counter
 import contextlib
@@ -38,13 +38,6 @@ from pydantic.utils import to_camel
 
 from pyunifiprotect.data.types import Version
 from pyunifiprotect.exceptions import NvrError
-
-# typer<0.4.1 is incompatible with click>=8.1.0
-# allows only the CLI interface to break if both are installed
-try:
-    import typer
-except ImportError:
-    typer = None  # type: ignore
 
 if TYPE_CHECKING:
     from pyunifiprotect.api import ProtectApiClient
@@ -305,6 +298,10 @@ async def write_json(output_path: Path, data: Union[List[Any], Dict[str, Any]]) 
 
 
 def print_ws_stat_summary(stats: List[WSStat], output: Optional[Callable[[Any], Any]] = None) -> None:
+    # typer<0.4.1 is incompatible with click>=8.1.0
+    # allows only the CLI interface to break if both are installed
+    import typer  # pylint: disable=import-outside-toplevel
+
     if output is None:
         if typer is not None:
             output = typer.echo

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from ast import Import
 
 import asyncio
 from collections import Counter
@@ -34,10 +35,16 @@ from uuid import UUID
 from aiohttp import ClientResponse
 from pydantic.fields import SHAPE_DICT, SHAPE_LIST, ModelField
 from pydantic.utils import to_camel
-import typer
 
 from pyunifiprotect.data.types import Version
 from pyunifiprotect.exceptions import NvrError
+
+# typer<0.4.1 is imcompatible with click>=8.1.0
+# allows only the CLI interface to break if both are installed
+try:
+    import typer
+except ImportError:
+    typer = None  # type: ignore
 
 if TYPE_CHECKING:
     from pyunifiprotect.api import ProtectApiClient
@@ -299,7 +306,10 @@ async def write_json(output_path: Path, data: Union[List[Any], Dict[str, Any]]) 
 
 def print_ws_stat_summary(stats: List[WSStat], output: Optional[Callable[[Any], Any]] = None) -> None:
     if output is None:
-        output = typer.echo
+        if typer is not None:
+            output = typer.echo
+        else:
+            output = print
 
     unfiltered, percent, keys, models, actions = ws_stat_summmary(stats)
 

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -39,7 +39,7 @@ from pydantic.utils import to_camel
 from pyunifiprotect.data.types import Version
 from pyunifiprotect.exceptions import NvrError
 
-# typer<0.4.1 is imcompatible with click>=8.1.0
+# typer<0.4.1 is incompatible with click>=8.1.0
 # allows only the CLI interface to break if both are installed
 try:
     import typer

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from ast import Import
 import asyncio
 from collections import Counter
 import contextlib

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -20,7 +20,7 @@ backcall==0.2.0
     # via ipython
 charset-normalizer==2.0.12
     # via aiohttp
-click==8.0.4
+click==8.1.3
     # via typer
 decorator==5.1.1
     # via ipython
@@ -48,23 +48,23 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==9.0.1
+pillow==9.1.0
     # via pyunifiprotect (setup.cfg)
-prompt-toolkit==3.0.28
+prompt-toolkit==3.0.29
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
 pydantic==1.9.0
     # via pyunifiprotect (setup.cfg)
-pygments==2.11.2
+pygments==2.12.0
     # via ipython
 pyjwt==2.3.0
     # via pyunifiprotect (setup.cfg)
-pyparsing==3.0.7
+pyparsing==3.0.8
     # via packaging
-python-dotenv==0.19.2
+python-dotenv==0.20.0
     # via pyunifiprotect (setup.cfg)
-pytz==2021.3
+pytz==2022.1
     # via pyunifiprotect (setup.cfg)
 termcolor==1.1.0
     # via pyunifiprotect (setup.cfg)
@@ -72,9 +72,9 @@ traitlets==5.1.1
     # via
     #   ipython
     #   matplotlib-inline
-typer==0.4.0
+typer==0.4.1
     # via pyunifiprotect (setup.cfg)
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via pydantic
 wcwidth==0.2.5
     # via prompt-toolkit

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,7 +10,7 @@ aioshutil==1.1
     # via pyunifiprotect (setup.cfg)
 aiosignal==1.2.0
     # via aiohttp
-astroid==2.9.3
+astroid==2.11.4
     # via pylint
 async-timeout==4.0.2
     # via aiohttp
@@ -24,23 +24,25 @@ backcall==0.2.0
     # via ipython
 base36==0.1.1
     # via pyunifiprotect (setup.cfg)
-black==22.1.0
+black==22.3.0
     # via pyunifiprotect (setup.cfg)
 build==0.7.0
     # via pyunifiprotect (setup.cfg)
 charset-normalizer==2.0.12
     # via aiohttp
-click==8.0.4
+click==8.1.3
     # via
     #   black
     #   pip-tools
     #   typer
-coverage[toml]==6.3.1
+coverage[toml]==6.3.2
     # via
     #   pytest-cov
     #   pyunifiprotect (setup.cfg)
 decorator==5.1.1
     # via ipython
+dill==0.3.4
+    # via pylint
 distlib==0.3.4
     # via virtualenv
 execnet==1.9.0
@@ -82,7 +84,7 @@ multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
-mypy==0.931
+mypy==0.950
     # via pyunifiprotect (setup.cfg)
 mypy-extensions==0.4.3
     # via
@@ -107,11 +109,11 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==9.0.1
+pillow==9.1.0
     # via pyunifiprotect (setup.cfg)
-pip-tools==6.5.1
+pip-tools==6.6.0
     # via pyunifiprotect (setup.cfg)
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via
     #   black
     #   pylint
@@ -120,7 +122,7 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-prompt-toolkit==3.0.28
+prompt-toolkit==3.0.29
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -141,21 +143,21 @@ pydocstyle==6.1.1
     #   pyunifiprotect (setup.cfg)
 pyflakes==2.4.0
     # via flake8
-pygments==2.11.2
+pygments==2.12.0
     # via ipython
 pyjwt==2.3.0
     # via pyunifiprotect (setup.cfg)
-pylint==2.12.2
+pylint==2.13.8
     # via
     #   pylint-strict-informational
     #   pyunifiprotect (setup.cfg)
 pylint-strict-informational==0.1
     # via pyunifiprotect (setup.cfg)
-pyparsing==3.0.7
+pyparsing==3.0.8
     # via packaging
-pyproject-flake8==0.0.1a2
+pyproject-flake8==0.0.1a4
     # via pyunifiprotect (setup.cfg)
-pytest==7.0.1
+pytest==7.1.2
     # via
     #   pytest-asyncio
     #   pytest-benchmark
@@ -165,7 +167,7 @@ pytest==7.0.1
     #   pytest-timeout
     #   pytest-xdist
     #   pyunifiprotect (setup.cfg)
-pytest-asyncio==0.18.1
+pytest-asyncio==0.18.3
     # via pyunifiprotect (setup.cfg)
 pytest-benchmark==3.4.1
     # via pyunifiprotect (setup.cfg)
@@ -179,9 +181,9 @@ pytest-timeout==2.1.0
     # via pyunifiprotect (setup.cfg)
 pytest-xdist==2.5.0
     # via pyunifiprotect (setup.cfg)
-python-dotenv==0.19.2
+python-dotenv==0.20.0
     # via pyunifiprotect (setup.cfg)
-pytz==2021.3
+pytz==2022.1
     # via pyunifiprotect (setup.cfg)
 six==1.16.0
     # via
@@ -194,10 +196,7 @@ termcolor==1.1.0
     #   pytest-sugar
     #   pyunifiprotect (setup.cfg)
 toml==0.10.2
-    # via
-    #   pylint
-    #   pyproject-flake8
-    #   tox
+    # via tox
 tomli==2.0.1
     # via
     #   black
@@ -205,32 +204,34 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   pep517
+    #   pylint
+    #   pyproject-flake8
     #   pytest
-tox==3.24.5
+tox==3.25.0
     # via pyunifiprotect (setup.cfg)
 traitlets==5.1.1
     # via
     #   ipython
     #   matplotlib-inline
-typer==0.4.0
+typer==0.4.1
     # via pyunifiprotect (setup.cfg)
-types-pillow==9.0.6
+types-pillow==9.0.14
     # via pyunifiprotect (setup.cfg)
-types-pytz==2021.3.5
+types-pytz==2021.3.7
     # via pyunifiprotect (setup.cfg)
-types-termcolor==1.1.3
+types-termcolor==1.1.4
     # via pyunifiprotect (setup.cfg)
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   mypy
     #   pydantic
-virtualenv==20.13.1
+virtualenv==20.14.1
     # via tox
 wcwidth==0.2.5
     # via prompt-toolkit
 wheel==0.37.1
     # via pip-tools
-wrapt==1.13.3
+wrapt==1.14.1
     # via astroid
 yarl==1.7.2
     # via aiohttp

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -215,9 +215,9 @@ traitlets==5.1.1
     #   matplotlib-inline
 typer==0.4.1
     # via pyunifiprotect (setup.cfg)
-types-pillow==9.0.14
+types-pillow==9.0.15
     # via pyunifiprotect (setup.cfg)
-types-pytz==2021.3.7
+types-pytz==2021.3.8
     # via pyunifiprotect (setup.cfg)
 types-termcolor==1.1.4
     # via pyunifiprotect (setup.cfg)

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     pyjwt
     python-dotenv
     pytz
-    typer
+    typer>=0.4.1
 
 [options.package_data]
 pyunifiprotect = py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     pyjwt
     python-dotenv
     pytz
-    typer>=0.4.1
+    typer
 
 [options.package_data]
 pyunifiprotect = py.typed


### PR DESCRIPTION
typer < 0.4.1 is not compatible with click >= 8.1.0. However, 0.4.1 should be compatible with both click < 8.10 and click >= 8.1.0.

Fixes https://github.com/home-assistant/core/issues/71422