### PR TITLE
Adds NVR CLI interface

### DIFF
--- a/pyunifiprotect/cli/base.py
+++ b/pyunifiprotect/cli/base.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+from pyunifiprotect.api import ProtectApiClient
+
+
+@dataclass
+class CliContext:
+    protect: ProtectApiClient

--- a/pyunifiprotect/cli/nvr.py
+++ b/pyunifiprotect/cli/nvr.py
@@ -1,0 +1,98 @@
+import asyncio
+from dataclasses import dataclass
+from datetime import timedelta
+import json
+from typing import Any, Coroutine
+
+import typer
+
+from pyunifiprotect.cli.base import CliContext
+from pyunifiprotect.data import NVR, ProtectBaseObject
+
+app = typer.Typer()
+
+ARG_TIMEOUT = typer.Argument(..., help="Timeout (in seconds)")
+ARG_DOORBELL_MESSAGE = typer.Argument(..., help="ASCII only. Max length 30")
+
+
+@dataclass
+class NVRContext(CliContext):
+    nvr: NVR
+
+
+def _run(ctx: typer.Context, func: Coroutine[Any, Any, None]) -> None:
+    async def callback() -> None:
+        await func
+        await ctx.obj.protect.close_session()
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(callback())
+
+
+def _print_unifi_obj(obj: ProtectBaseObject) -> None:
+    typer.echo(json.dumps(obj.unifi_dict(), indent=2))
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context) -> None:
+    """UniFi Protect NVR CLI"""
+
+    context = NVRContext(protect=ctx.obj.protect, nvr=ctx.obj.protect.bootstrap.nvr)
+    ctx.obj = context
+
+    if not ctx.invoked_subcommand:
+        _print_unifi_obj(context.nvr)
+
+
+@app.command()
+def protect_url(ctx: typer.Context) -> None:
+    """Gets UniFi Protect management URL."""
+
+    nvr: NVR = ctx.obj.nvr
+    typer.echo(nvr.protect_url)
+
+
+@app.command()
+def set_default_reset_timeout(ctx: typer.Context, timeout: int = ARG_TIMEOUT) -> None:
+    """
+    Sets default message reset timeout.
+
+    This is how long until a custom message is reset back to the default message if no
+    timeout is passed in when the custom message is set.
+    """
+
+    nvr: NVR = ctx.obj.nvr
+    _run(ctx, nvr.set_default_reset_timeout(timedelta(seconds=timeout)))
+    _print_unifi_obj(nvr.doorbell_settings)
+
+
+@app.command()
+def set_default_doorbell_message(ctx: typer.Context, msg: str = ARG_DOORBELL_MESSAGE) -> None:
+    """
+    Sets default message for doorbell.
+
+    This is the message that is set when a custom doorbell message times out or an empty
+    one is set.
+    """
+
+    nvr: NVR = ctx.obj.nvr
+    _run(ctx, nvr.set_default_doorbell_message(msg))
+    _print_unifi_obj(nvr.doorbell_settings)
+
+
+@app.command()
+def add_custom_doorbell_message(ctx: typer.Context, msg: str = ARG_DOORBELL_MESSAGE) -> None:
+    """Adds a custom doorbell message."""
+
+    nvr: NVR = ctx.obj.nvr
+    _run(ctx, nvr.add_custom_doorbell_message(msg))
+    _print_unifi_obj(nvr.doorbell_settings)
+
+
+@app.command()
+def remove_custom_doorbell_message(ctx: typer.Context, msg: str = ARG_DOORBELL_MESSAGE) -> None:
+    """Removes a custom doorbell message."""
+
+    nvr: NVR = ctx.obj.nvr
+    _run(ctx, nvr.remove_custom_doorbell_message(msg))
+    _print_unifi_obj(nvr.doorbell_settings)

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -344,13 +344,17 @@ class ProtectBaseObject(BaseModel):
 
         return data
 
-    def _unifi_dict_protect_obj(self, data: Dict[str, Any], key: str, use_obj: bool) -> Any:
+    def _unifi_dict_protect_obj(
+        self, data: Dict[str, Any], key: str, use_obj: bool, klass: Type[ProtectBaseObject]
+    ) -> Any:
         value: Optional[Any] = data.get(key)
         if use_obj:
             value = getattr(self, key)
 
         if isinstance(value, ProtectBaseObject):
             value = value.unifi_dict()
+        elif isinstance(value, dict):
+            value = klass.construct({}).unifi_dict(data=value)  # type: ignore
 
         return value
 
@@ -410,9 +414,9 @@ class ProtectBaseObject(BaseModel):
             data = self.dict(exclude=excluded_fields)
             use_obj = True
 
-        for key in self._get_protect_objs().keys():
+        for key, klass in self._get_protect_objs().items():
             if use_obj or key in data:
-                data[key] = self._unifi_dict_protect_obj(data, key, use_obj)
+                data[key] = self._unifi_dict_protect_obj(data, key, use_obj, klass)
 
         for key in self._get_protect_lists().keys():
             if use_obj or key in data:

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -393,7 +393,12 @@ class LCDMessage(ProtectBaseObject):
         data = super().unifi_dict(data=data, exclude=exclude)
 
         if "text" in data:
-            data["text"] = self._fix_text(data["text"], data.get("type", self.type.value))
+            try:
+                msg_type = self.type.value
+            except AttributeError:
+                msg_type = None
+
+            data["text"] = self._fix_text(data["text"], data.get("type", msg_type))
         if "resetAt" in data:
             data["resetAt"] = to_js_time(data["resetAt"])
 

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -503,10 +503,6 @@ class DoorbellSettings(ProtectBaseObject):
     def _get_unifi_remaps(cls) -> Dict[str, str]:
         return {**super()._get_unifi_remaps(), "defaultMessageResetTimeoutMs": "defaultMessageResetTimeout"}
 
-    def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
-        data = super().unifi_dict(data, exclude)
-        return data
-
     @classmethod
     def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "defaultMessageResetTimeoutMs" in data:

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -503,6 +503,10 @@ class DoorbellSettings(ProtectBaseObject):
     def _get_unifi_remaps(cls) -> Dict[str, str]:
         return {**super()._get_unifi_remaps(), "defaultMessageResetTimeoutMs": "defaultMessageResetTimeout"}
 
+    def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
+        data = super().unifi_dict(data, exclude)
+        return data
+
     @classmethod
     def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "defaultMessageResetTimeoutMs" in data:

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -78,11 +78,14 @@ async def get_response_reason(response: ClientResponse) -> str:
     return reason
 
 
-def to_js_time(dt: Optional[datetime]) -> Optional[int]:
+def to_js_time(dt: datetime | int | None) -> Optional[int]:
     """Converts Python datetime to Javascript timestamp"""
 
     if dt is None:
         return None
+
+    if isinstance(dt, int):
+        return dt
 
     if dt.tzinfo is None:
         return int(time.mktime(dt.timetuple()) * 1000)

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ dev =
     coverage[toml]
     flake8
     flake8-docstrings
-    ipython<7.32
+    ipython
     mypy
     pip-tools
     pydocstyle
@@ -71,5 +71,5 @@ dev =
     types-pytz
     types-termcolor
 shell=
-    ipython<7.32
+    ipython
     termcolor

--- a/tests/data/test_nvr.py
+++ b/tests/data/test_nvr.py
@@ -22,7 +22,7 @@ async def test_nvr_set_default_reset_timeout(nvr_obj: NVR):
     nvr_obj.api.api_request.assert_called_with(
         "nvr",
         method="patch",
-        json={"doorbellSettings": {"defaultMessageResetTimeout": to_ms(duration)}},
+        json={"doorbellSettings": {"defaultMessageResetTimeoutMs": to_ms(duration)}},
     )
 
 


### PR DESCRIPTION
Start of adding a full CLI interface for the library.

* Moves shared CLI options to `unifi-protect` root command
    * Technically a breaking change, but the CLI interface before this PR was only for CI and debugging. This is the start of stabilizing it. The preferred way is still via ENVs anyways.
* Refactors the root commands to use a context obj to initialize and share UniFi Protect instance
* Adds `nvr` command group that provides interfaces for interacting with `NVR` class (works great with `jq`)
* Fixes child `ProtectBaseObj` not being serialized correctly for `save_device`