### PR TITLE
Remove asyncio

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ include_package_data = True
 install_requires =
     aiohttp
     aioshutil
-    asyncio
     packaging
     pillow
     pydantic!=1.9.1 # https://github.com/samuelcolvin/pydantic/issues/4092


### PR DESCRIPTION
`asyncio` is a Python standard module.