### PR TITLE
Adds common CLI commands for all UFP devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The command line has a fully featured help, so the best way to discovery and lea
 
 #### Examples
 
-#### List all adopted cameras
+#### List All Cameras
 
 ```bash
 $ unifi-protect cameras list-ids
@@ -71,7 +71,14 @@ $ unifi-protect cameras list-ids
 61be1d2f004bda03e700ab12: G4 Dome
 ```
 
-#### Enable SSH on camera
+#### Check if a Camera is Online
+
+```bash
+$ unifi-protect cameras 61ddb66b018e2703e7008c19 | jq .isConnected
+true
+```
+
+#### Enable SSH on Camera
 
 ```bash
 $ unifi-protect cameras 61ddb66b018e2703e7008c19 set-ssh true

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ true
 $ unifi-protect lights 61b3f5c801f8a703e7000428 reboot
 ```
 
+#### Reboot All Cameras
+
+```bash
+for id in $(unifi-protect cameras list-ids | awk '{ print $1 }'); do
+    unifi-protect cameras $id reboot
+done
+```
 
 ## Library Usage
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,76 @@ Requires Unifi Protect version 1.20 or higher and Python 3.9+.
 pip install pyunifiprotect
 ```
 
-## Usage
+## CLI Usage
+
+The `unifi-protect` command is provided to give a CLI interface to interact with your UniFi Protect instance as well. All
+commands support JSON output so it works great with `jq` for complex scripting.
+
+### Authentication
+
+Following traditional [twelve factor app design](https://12factor.net/), the perfered way to provided authentication
+credentials to provided environment variables, but CLI args are also supported.
+
+#### Environment Variables
+
+```bash
+export UFP_USERNAME=YOUR_USERNAME_HERE
+export UFP_PASSWORD=YOUR_PASSWORD_HERE
+export UFP_ADDRESS=YOUR_IP_ADDRESS
+export UFP_PORT=443
+# change to false if you do not have a valid HTTPS Certificate for your instance
+export UFP_SSL_VERIFY=True
+
+unifi-protect nvr
+```
+
+#### CLI Args
+
+```bash
+unifi-protect -U YOUR_USERNAME_HERE -P YOUR_PASSWORD_HERE -a YOUR_IP_ADDRESS -p 443 --no-verify nvr
+```
+
+### Subcommands
+
+The command line has a fully featured help, so the best way to discovery and learn all of the possible commands is to use `unifi-protect --help`
+
+* `nvr` - Interact with your NVR console
+* `camera`, `chimes`, `doorlocks`, `lights`, `sensors`, `viewers` - Interact with specific devices on adopted by your UniFi protect instance
+* `shell` - Interactive IPyton shell (requires `pyunifiprotect[shell]` extra to be installed) with `ProtectApiClient already initalized
+* `decode-ws-msg` - Mostly for debug purposes to debug a base64 binary Websocket message from UniFi Protect
+* `generate-sample-data` - Mostly for debug purposes to generate fake data for CI / testing. Can also be used to share the current state of your UniFi Protect instance.
+* `profile-ws` - Mostly for debug purposes to profile the number of ignored/processed Websocket messages
+
+#### Examples
+
+#### List all adopted cameras
+
+```bash
+$ unifi-protect cameras list-ids
+
+61b3f5c7033ea703e7000424: G4 Bullet
+61f9824e004adc03e700132c: G4 PTZ
+61be1d2f004bda03e700ab12: G4 Dome
+```
+
+#### Enable SSH on camera
+
+```bash
+$ unifi-protect cameras 61ddb66b018e2703e7008c19 set-ssh true
+
+# get current value to verify
+$ unifi-protect cameras 61ddb66b018e2703e7008c19 | jq .isSshEnabled
+true
+```
+
+#### Reboot Flood Light
+
+```bash
+$ unifi-protect lights 61b3f5c801f8a703e7000428 reboot
+```
+
+
+## Library Usage
 
 Unifi Protect itself is 100% async, so as such this library is primarily designed to be used in an async context.
 

--- a/pyunifiprotect/cli/base.py
+++ b/pyunifiprotect/cli/base.py
@@ -64,7 +64,7 @@ def list_ids(ctx: typer.Context) -> None:
         json_output(to_print)
     else:
         for item in to_print:
-            typer.echo(f"{item[0]}: {item[1]}")
+            typer.echo(f"{item[0]}\t{item[1]}")
 
 
 def protect_url(ctx: typer.Context) -> None:

--- a/pyunifiprotect/cli/base.py
+++ b/pyunifiprotect/cli/base.py
@@ -1,8 +1,140 @@
+import asyncio
 from dataclasses import dataclass
+from enum import Enum
+import json
+from typing import Any, Callable, Coroutine, Mapping
+
+import typer
 
 from pyunifiprotect.api import ProtectApiClient
+from pyunifiprotect.data import NVR, ProtectAdoptableDeviceModel, ProtectBaseObject
+
+
+class OutputFormatEnum(str, Enum):
+    JSON = "json"
+    PLAIN = "plain"
 
 
 @dataclass
 class CliContext:
     protect: ProtectApiClient
+    output_format: OutputFormatEnum
+
+
+def run(ctx: typer.Context, func: Coroutine[Any, Any, None]) -> None:
+    """Helper method to call async function and clean up API client"""
+
+    async def callback() -> None:
+        await func
+        await ctx.obj.protect.close_session()
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(callback())
+
+
+def json_output(obj: Any) -> None:
+    typer.echo(json.dumps(obj, indent=2))
+
+
+def print_unifi_obj(obj: ProtectBaseObject) -> None:
+    """Helper method to print a single protect object"""
+
+    json_output(obj.unifi_dict())
+
+
+def print_unifi_dict(objs: Mapping[str, ProtectBaseObject]) -> None:
+    """Helper method to print a dictionary of protect objects"""
+
+    data = {}
+    for key, obj in objs.items():
+        data[key] = obj.unifi_dict()
+
+    json_output(data)
+
+
+def list_ids(ctx: typer.Context) -> None:
+    """Prints list of id: name for each device."""
+
+    objs: dict[str, ProtectAdoptableDeviceModel] = ctx.obj.devices
+    to_print: list[tuple[str, str | None]] = []
+    for obj in objs.values():
+        to_print.append((obj.id, obj.name))
+
+    if ctx.obj.output_format == OutputFormatEnum.JSON:
+        json_output(to_print)
+    else:
+        for item in to_print:
+            typer.echo(f"{item[0]}: {item[1]}")
+
+
+def protect_url(ctx: typer.Context) -> None:
+    """Gets UniFi Protect management URL."""
+
+    obj: NVR | ProtectAdoptableDeviceModel = ctx.obj.device
+    if ctx.obj.output_format == OutputFormatEnum.JSON:
+        json_output(obj.protect_url)
+    else:
+        typer.echo(obj.protect_url)
+
+
+def is_wired(ctx: typer.Context) -> None:
+    """Returns if the device is wired or not."""
+
+    obj: ProtectAdoptableDeviceModel = ctx.obj.device
+    json_output(obj.is_wired)
+
+
+def is_wifi(ctx: typer.Context) -> None:
+    """Returns if the device has WiFi or not."""
+
+    obj: ProtectAdoptableDeviceModel = ctx.obj.device
+    json_output(obj.is_wifi)
+
+
+def is_bluetooth(ctx: typer.Context) -> None:
+    """Returns if the device has Bluetooth or not."""
+
+    obj: ProtectAdoptableDeviceModel = ctx.obj.device
+    json_output(obj.is_bluetooth)
+
+
+def bridge(ctx: typer.Context) -> None:
+    """Returns bridge device if connected via Bluetooth."""
+
+    obj: ProtectAdoptableDeviceModel = ctx.obj.device
+    json_output(obj.bridge)
+
+
+def set_ssh(ctx: typer.Context, enabled: bool) -> None:
+    """
+    Sets the isSshEnabled value for device.
+
+    May not have an effect on many device types. Only seems to work for
+    Linux and BusyBox based devices (camera, light and viewport).
+    """
+
+    obj: ProtectAdoptableDeviceModel = ctx.obj.device
+    run(ctx, obj.set_ssh(enabled))
+
+
+def reboot(ctx: typer.Context) -> None:
+    """Reboots the device."""
+
+    obj: ProtectAdoptableDeviceModel = ctx.obj.device
+    run(ctx, obj.reboot())
+
+
+def init_common_commands(app: typer.Typer) -> tuple[dict[str, Callable[..., Any]], dict[str, Callable[..., Any]]]:
+    deviceless_commands: dict[str, Callable[..., Any]] = {}
+    device_commands: dict[str, Callable[..., Any]] = {}
+
+    deviceless_commands["list-ids"] = app.command()(list_ids)
+    device_commands["protect-url"] = app.command()(protect_url)
+    device_commands["is-wired"] = app.command()(is_wired)
+    device_commands["is-wifi"] = app.command()(is_wifi)
+    device_commands["is-bluetooth"] = app.command()(is_bluetooth)
+    device_commands["bridge"] = app.command()(bridge)
+    device_commands["set-ssh"] = app.command()(set_ssh)
+    device_commands["reboot"] = app.command()(reboot)
+
+    return deviceless_commands, device_commands

--- a/pyunifiprotect/cli/cameras.py
+++ b/pyunifiprotect/cli/cameras.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import typer
+
+from pyunifiprotect.api import ProtectApiClient
+from pyunifiprotect.cli import base
+from pyunifiprotect.data import Camera
+
+app = typer.Typer()
+
+ARG_DEVICE_ID = typer.Argument(None, help="ID of camera to select for subcommands")
+
+
+@dataclass
+class CameraContext(base.CliContext):
+    devices: dict[str, Camera]
+    device: Camera | None = None
+
+
+ALL_COMMANDS, DEVICE_COMMANDS = base.init_common_commands(app)
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context, device_id: Optional[str] = ARG_DEVICE_ID) -> None:
+    """
+    UniFi Protect Camera CLI.
+
+    Returns full list of Cameras without any arguments passed.
+    """
+
+    protect: ProtectApiClient = ctx.obj.protect
+    context = CameraContext(
+        protect=ctx.obj.protect, device=None, devices=protect.bootstrap.cameras, output_format=ctx.obj.output_format
+    )
+    ctx.obj = context
+
+    if device_id is not None and device_id not in ALL_COMMANDS:
+        if (device := protect.bootstrap.cameras.get(device_id)) is None:
+            typer.secho("Invalid camera ID", fg="red")
+            raise typer.Exit(1)
+        ctx.obj.device = device
+
+    if not ctx.invoked_subcommand:
+        if device_id in ALL_COMMANDS:
+            ctx.invoke(ALL_COMMANDS[device_id], ctx)
+            return
+
+        if ctx.obj.device is not None:
+            base.print_unifi_obj(ctx.obj.device)
+            return
+
+        base.print_unifi_dict(ctx.obj.devices)

--- a/pyunifiprotect/cli/chimes.py
+++ b/pyunifiprotect/cli/chimes.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import typer
+
+from pyunifiprotect.api import ProtectApiClient
+from pyunifiprotect.cli import base
+from pyunifiprotect.data import Chime
+
+app = typer.Typer()
+
+ARG_DEVICE_ID = typer.Argument(None, help="ID of chime to select for subcommands")
+
+
+@dataclass
+class ChimeContext(base.CliContext):
+    devices: dict[str, Chime]
+    device: Chime | None = None
+
+
+ALL_COMMANDS, DEVICE_COMMANDS = base.init_common_commands(app)
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context, device_id: Optional[str] = ARG_DEVICE_ID) -> None:
+    """
+    UniFi Protect Chime CLI.
+
+    Returns full list of Chimes without any arguments passed.
+    """
+
+    protect: ProtectApiClient = ctx.obj.protect
+    context = ChimeContext(
+        protect=ctx.obj.protect, device=None, devices=protect.bootstrap.chimes, output_format=ctx.obj.output_format
+    )
+    ctx.obj = context
+
+    if device_id is not None and device_id not in ALL_COMMANDS:
+        if (device := protect.bootstrap.chimes.get(device_id)) is None:
+            typer.secho("Invalid chime ID", fg="red")
+            raise typer.Exit(1)
+        ctx.obj.device = device
+
+    if not ctx.invoked_subcommand:
+        if device_id in ALL_COMMANDS:
+            ctx.invoke(ALL_COMMANDS[device_id], ctx)
+            return
+
+        if ctx.obj.device is not None:
+            base.print_unifi_obj(ctx.obj.device)
+            return
+
+        base.print_unifi_dict(ctx.obj.devices)

--- a/pyunifiprotect/cli/doorlocks.py
+++ b/pyunifiprotect/cli/doorlocks.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import typer
+
+from pyunifiprotect.api import ProtectApiClient
+from pyunifiprotect.cli import base
+from pyunifiprotect.data import Doorlock
+
+app = typer.Typer()
+
+ARG_DEVICE_ID = typer.Argument(None, help="ID of doorlock to select for subcommands")
+
+
+@dataclass
+class DoorlockContext(base.CliContext):
+    devices: dict[str, Doorlock]
+    device: Doorlock | None = None
+
+
+ALL_COMMANDS, DEVICE_COMMANDS = base.init_common_commands(app)
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context, device_id: Optional[str] = ARG_DEVICE_ID) -> None:
+    """
+    UniFi Protect Doorlock CLI.
+
+    Returns full list of Doorlocks without any arguments passed.
+    """
+
+    protect: ProtectApiClient = ctx.obj.protect
+    context = DoorlockContext(
+        protect=ctx.obj.protect, device=None, devices=protect.bootstrap.doorlocks, output_format=ctx.obj.output_format
+    )
+    ctx.obj = context
+
+    if device_id is not None and device_id not in ALL_COMMANDS:
+        if (device := protect.bootstrap.doorlocks.get(device_id)) is None:
+            typer.secho("Invalid doorlock ID", fg="red")
+            raise typer.Exit(1)
+        ctx.obj.device = device
+
+    if not ctx.invoked_subcommand:
+        if device_id in ALL_COMMANDS:
+            ctx.invoke(ALL_COMMANDS[device_id], ctx)
+            return
+
+        if ctx.obj.device is not None:
+            base.print_unifi_obj(ctx.obj.device)
+            return
+
+        base.print_unifi_dict(ctx.obj.devices)

--- a/pyunifiprotect/cli/light.py
+++ b/pyunifiprotect/cli/light.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import typer
+
+from pyunifiprotect.api import ProtectApiClient
+from pyunifiprotect.cli import base
+from pyunifiprotect.data import Light
+
+app = typer.Typer()
+
+ARG_DEVICE_ID = typer.Argument(None, help="ID of light to select for subcommands")
+
+
+@dataclass
+class LightContext(base.CliContext):
+    devices: dict[str, Light]
+    device: Light | None = None
+
+
+ALL_COMMANDS, DEVICE_COMMANDS = base.init_common_commands(app)
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context, device_id: Optional[str] = ARG_DEVICE_ID) -> None:
+    """
+    UniFi Protect Light CLI.
+
+    Returns full list of Viewers without any arguments passed.
+    """
+
+    protect: ProtectApiClient = ctx.obj.protect
+    context = LightContext(
+        protect=ctx.obj.protect, device=None, devices=protect.bootstrap.lights, output_format=ctx.obj.output_format
+    )
+    ctx.obj = context
+
+    if device_id is not None and device_id not in ALL_COMMANDS:
+        if (device := protect.bootstrap.lights.get(device_id)) is None:
+            typer.secho("Invalid light ID", fg="red")
+            raise typer.Exit(1)
+        ctx.obj.device = device
+
+    if not ctx.invoked_subcommand:
+        if device_id in ALL_COMMANDS:
+            ctx.invoke(ALL_COMMANDS[device_id], ctx)
+            return
+
+        if ctx.obj.device is not None:
+            base.print_unifi_obj(ctx.obj.device)
+            return
+
+        base.print_unifi_dict(ctx.obj.devices)

--- a/pyunifiprotect/cli/nvr.py
+++ b/pyunifiprotect/cli/nvr.py
@@ -1,13 +1,10 @@
-import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
-import json
-from typing import Any, Coroutine
 
 import typer
 
-from pyunifiprotect.cli.base import CliContext
-from pyunifiprotect.data import NVR, ProtectBaseObject
+from pyunifiprotect.cli.base import CliContext, print_unifi_obj, protect_url, run
+from pyunifiprotect.data import NVR
 
 app = typer.Typer()
 
@@ -17,39 +14,27 @@ ARG_DOORBELL_MESSAGE = typer.Argument(..., help="ASCII only. Max length 30")
 
 @dataclass
 class NVRContext(CliContext):
-    nvr: NVR
-
-
-def _run(ctx: typer.Context, func: Coroutine[Any, Any, None]) -> None:
-    async def callback() -> None:
-        await func
-        await ctx.obj.protect.close_session()
-
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(callback())
-
-
-def _print_unifi_obj(obj: ProtectBaseObject) -> None:
-    typer.echo(json.dumps(obj.unifi_dict(), indent=2))
+    device: NVR
 
 
 @app.callback(invoke_without_command=True)
 def main(ctx: typer.Context) -> None:
-    """UniFi Protect NVR CLI"""
+    """
+    UniFi Protect NVR CLI.
 
-    context = NVRContext(protect=ctx.obj.protect, nvr=ctx.obj.protect.bootstrap.nvr)
+    Return NVR object without any arguments passed.
+    """
+
+    context = NVRContext(
+        protect=ctx.obj.protect, device=ctx.obj.protect.bootstrap.nvr, output_format=ctx.obj.output_format
+    )
     ctx.obj = context
 
     if not ctx.invoked_subcommand:
-        _print_unifi_obj(context.nvr)
+        print_unifi_obj(context.device)
 
 
-@app.command()
-def protect_url(ctx: typer.Context) -> None:
-    """Gets UniFi Protect management URL."""
-
-    nvr: NVR = ctx.obj.nvr
-    typer.echo(nvr.protect_url)
+app.command()(protect_url)
 
 
 @app.command()
@@ -61,9 +46,9 @@ def set_default_reset_timeout(ctx: typer.Context, timeout: int = ARG_TIMEOUT) ->
     timeout is passed in when the custom message is set.
     """
 
-    nvr: NVR = ctx.obj.nvr
-    _run(ctx, nvr.set_default_reset_timeout(timedelta(seconds=timeout)))
-    _print_unifi_obj(nvr.doorbell_settings)
+    nvr: NVR = ctx.obj.device
+    run(ctx, nvr.set_default_reset_timeout(timedelta(seconds=timeout)))
+    print_unifi_obj(nvr.doorbell_settings)
 
 
 @app.command()
@@ -75,24 +60,24 @@ def set_default_doorbell_message(ctx: typer.Context, msg: str = ARG_DOORBELL_MES
     one is set.
     """
 
-    nvr: NVR = ctx.obj.nvr
-    _run(ctx, nvr.set_default_doorbell_message(msg))
-    _print_unifi_obj(nvr.doorbell_settings)
+    nvr: NVR = ctx.obj.device
+    run(ctx, nvr.set_default_doorbell_message(msg))
+    print_unifi_obj(nvr.doorbell_settings)
 
 
 @app.command()
 def add_custom_doorbell_message(ctx: typer.Context, msg: str = ARG_DOORBELL_MESSAGE) -> None:
     """Adds a custom doorbell message."""
 
-    nvr: NVR = ctx.obj.nvr
-    _run(ctx, nvr.add_custom_doorbell_message(msg))
-    _print_unifi_obj(nvr.doorbell_settings)
+    nvr: NVR = ctx.obj.device
+    run(ctx, nvr.add_custom_doorbell_message(msg))
+    print_unifi_obj(nvr.doorbell_settings)
 
 
 @app.command()
 def remove_custom_doorbell_message(ctx: typer.Context, msg: str = ARG_DOORBELL_MESSAGE) -> None:
     """Removes a custom doorbell message."""
 
-    nvr: NVR = ctx.obj.nvr
-    _run(ctx, nvr.remove_custom_doorbell_message(msg))
-    _print_unifi_obj(nvr.doorbell_settings)
+    nvr: NVR = ctx.obj.device
+    run(ctx, nvr.remove_custom_doorbell_message(msg))
+    print_unifi_obj(nvr.doorbell_settings)

--- a/pyunifiprotect/cli/sensors.py
+++ b/pyunifiprotect/cli/sensors.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import typer
+
+from pyunifiprotect.api import ProtectApiClient
+from pyunifiprotect.cli import base
+from pyunifiprotect.data import Sensor
+
+app = typer.Typer()
+
+ARG_DEVICE_ID = typer.Argument(None, help="ID of sensor to select for subcommands")
+
+
+@dataclass
+class SensorContext(base.CliContext):
+    devices: dict[str, Sensor]
+    device: Sensor | None = None
+
+
+ALL_COMMANDS, DEVICE_COMMANDS = base.init_common_commands(app)
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context, device_id: Optional[str] = ARG_DEVICE_ID) -> None:
+    """
+    UniFi Protect Sensor CLI.
+
+    Returns full list of Sensors without any arguments passed.
+    """
+
+    protect: ProtectApiClient = ctx.obj.protect
+    context = SensorContext(
+        protect=ctx.obj.protect, device=None, devices=protect.bootstrap.sensors, output_format=ctx.obj.output_format
+    )
+    ctx.obj = context
+
+    if device_id is not None and device_id not in ALL_COMMANDS:
+        if (device := protect.bootstrap.sensors.get(device_id)) is None:
+            typer.secho("Invalid sensor ID", fg="red")
+            raise typer.Exit(1)
+        ctx.obj.device = device
+
+    if not ctx.invoked_subcommand:
+        if device_id in ALL_COMMANDS:
+            ctx.invoke(ALL_COMMANDS[device_id], ctx)
+            return
+
+        if ctx.obj.device is not None:
+            base.print_unifi_obj(ctx.obj.device)
+            return
+
+        base.print_unifi_dict(ctx.obj.devices)

--- a/pyunifiprotect/cli/viewers.py
+++ b/pyunifiprotect/cli/viewers.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import typer
+
+from pyunifiprotect.api import ProtectApiClient
+from pyunifiprotect.cli import base
+from pyunifiprotect.data import Viewer
+
+app = typer.Typer()
+
+ARG_DEVICE_ID = typer.Argument(None, help="ID of viewer to select for subcommands")
+
+
+@dataclass
+class ViewerContext(base.CliContext):
+    devices: dict[str, Viewer]
+    device: Viewer | None = None
+
+
+ALL_COMMANDS, DEVICE_COMMANDS = base.init_common_commands(app)
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context, device_id: Optional[str] = ARG_DEVICE_ID) -> None:
+    """
+    UniFi Protect Viewer CLI.
+
+    Returns full list of Viewers without any arguments passed.
+    """
+
+    protect: ProtectApiClient = ctx.obj.protect
+    context = ViewerContext(
+        protect=ctx.obj.protect, device=None, devices=protect.bootstrap.viewers, output_format=ctx.obj.output_format
+    )
+    ctx.obj = context
+
+    if device_id is not None and device_id not in ALL_COMMANDS:
+        if (device := protect.bootstrap.viewers.get(device_id)) is None:
+            typer.secho("Invalid viewer ID", fg="red")
+            raise typer.Exit(1)
+        ctx.obj.device = device
+
+    if not ctx.invoked_subcommand:
+        if device_id in ALL_COMMANDS:
+            ctx.invoke(ALL_COMMANDS[device_id], ctx)
+            return
+
+        if ctx.obj.device is not None:
+            base.print_unifi_obj(ctx.obj.device)
+            return
+
+        base.print_unifi_dict(ctx.obj.devices)


### PR DESCRIPTION
Adds the following commands for all adoptable device types. Some commands may be redundant/useless on some device types.

* base -  list all devices (full JSON list, basically the same thing as `/cameras`, `/lights`, etc. API endpoints)
* `list-ids` - list of ID: name of each device
* `[id]` - list full JSON for device, basically the same thing as `/cameras/{id}`, `/lights{id}`, etc. API endpoints)
* `{id} protect-url` - gets Web app management URL for device
* `{id} is-wired` - returns if device is wired (has active Wired connection)
* `{id} is-wifi` - returns if device is WiFi enabled (has WiFi antenna)
* `{id} is-bluetooth` - returns if device is Bluetooth enabled (pairs via a U6 AP using Bluetooth, such as Doorlock and Smart Sensor)
* `{id} bridge` - returns full JSON for the bridge the Bluetooth device is connected to
* `{id} set-ssh {enabled}` - enables/disables SSH for device. Only has a real effect on Linux/BusyBox based devices (camera, light and viewport)
*  `{id} reboot` - reboots a device