### PR TITLE
Fill out more fields accurately

### DIFF
--- a/pyunifiprotect/cli/cameras.py
+++ b/pyunifiprotect/cli/cameras.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 

--- a/pyunifiprotect/cli/doorlocks.py
+++ b/pyunifiprotect/cli/doorlocks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Optional

--- a/pyunifiprotect/cli/light.py
+++ b/pyunifiprotect/cli/light.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Optional

--- a/pyunifiprotect/cli/liveviews.py
+++ b/pyunifiprotect/cli/liveviews.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 

--- a/pyunifiprotect/cli/nvr.py
+++ b/pyunifiprotect/cli/nvr.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import typer
 
 from pyunifiprotect.cli.base import CliContext, print_unifi_obj, protect_url, run
-from pyunifiprotect.data import NVR
+from pyunifiprotect.data import NVR, AnalyticsOption
 
 app = typer.Typer()
 
@@ -35,6 +35,14 @@ def main(ctx: typer.Context) -> None:
 
 
 app.command()(protect_url)
+
+
+@app.command()
+def set_analytics(ctx: typer.Context, value: AnalyticsOption) -> None:
+    """Sets analytics collection for NVR."""
+
+    nvr: NVR = ctx.obj.device
+    run(ctx, nvr.set_analytics(value))
 
 
 @app.command()

--- a/pyunifiprotect/cli/sensors.py
+++ b/pyunifiprotect/cli/sensors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 

--- a/pyunifiprotect/cli/viewers.py
+++ b/pyunifiprotect/cli/viewers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 

--- a/pyunifiprotect/data/__init__.py
+++ b/pyunifiprotect/data/__init__.py
@@ -21,6 +21,7 @@ from pyunifiprotect.data.devices import (
 from pyunifiprotect.data.nvr import (
     NVR,
     CloudAccount,
+    DoorbellMessage,
     Event,
     Group,
     Liveview,
@@ -33,6 +34,7 @@ from pyunifiprotect.data.nvr import (
 from pyunifiprotect.data.types import (
     DEFAULT,
     DEFAULT_TYPE,
+    AnalyticsOption,
     ChimeDuration,
     ChimeType,
     Color,
@@ -69,6 +71,7 @@ from pyunifiprotect.data.websocket import (
 )
 
 __all__ = [
+    "AnalyticsOption",
     "Bootstrap",
     "Bridge",
     "Camera",
@@ -82,6 +85,7 @@ __all__ = [
     "create_from_unifi_dict",
     "DEFAULT_TYPE",
     "DEFAULT",
+    "DoorbellMessage",
     "DoorbellMessageType",
     "DoorbellText",
     "Doorlock",

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -20,21 +20,31 @@ from pyunifiprotect.data.base import (
 from pyunifiprotect.data.types import (
     DEFAULT,
     DEFAULT_TYPE,
+    AudioCodecs,
+    AutoExposureMode,
     ChimeDuration,
     ChimeType,
     Color,
     DoorbellMessageType,
+    FocusMode,
+    GeofencingSetting,
+    ICRSensitivity,
     IRLEDMode,
     LEDLevel,
     LightModeEnableType,
     LightModeType,
     LockStatusType,
+    LowMedHigh,
+    MotionAlgorithm,
+    MountPosition,
     MountType,
     Percent,
     PercentInt,
     RecordingMode,
     SensorStatusType,
+    SleepStateType,
     SmartDetectObjectType,
+    TwoByteInt,
     VideoMode,
     WDRLevel,
 )
@@ -61,8 +71,7 @@ class LightDeviceSettings(ProtectBaseObject):
     is_indicator_enabled: bool
     # Brightness
     led_level: LEDLevel
-    # unknown
-    lux_sensitivity: str
+    lux_sensitivity: LowMedHigh
     pir_duration: timedelta
     pir_sensitivity: PercentInt
 
@@ -251,11 +260,11 @@ class CameraChannel(ProtectBaseObject):
 
 
 class ISPSettings(ProtectBaseObject):
-    ae_mode: str
+    ae_mode: AutoExposureMode
     ir_led_mode: IRLEDMode
-    ir_led_level: int
+    ir_led_level: TwoByteInt
     wdr: WDRLevel
-    icr_sensitivity: int
+    icr_sensitivity: ICRSensitivity
     brightness: int
     contrast: int
     hue: int
@@ -274,14 +283,12 @@ class ISPSettings(ProtectBaseObject):
     d_zoom_center_y: int
     d_zoom_scale: int
     d_zoom_stream_id: int
-    focus_mode: str
+    focus_mode: FocusMode
     focus_position: int
     touch_focus_x: int
     touch_focus_y: int
     zoom_position: PercentInt
-
-    # TODO:
-    # mountPosition
+    mount_position: MountPosition | None = None
 
 
 class OSDSettings(ProtectBaseObject):
@@ -295,7 +302,7 @@ class OSDSettings(ProtectBaseObject):
 class LEDSettings(ProtectBaseObject):
     # Status Light
     is_enabled: bool
-    blink_rate: int
+    blink_rate: int  # in milliseconds betweeen blinks, 0 = solid
 
 
 class SpeakerSettings(ProtectBaseObject):
@@ -316,8 +323,8 @@ class RecordingSettings(ProtectBaseObject):
     suppress_illumination_surge: bool
     # High Frame Rate Mode
     mode: RecordingMode
-    geofencing: str
-    motion_algorithm: str
+    geofencing: GeofencingSetting
+    motion_algorithm: MotionAlgorithm
     enable_motion_detection: Optional[bool] = None
     enable_pir_timelapse: bool
     use_new_motion_algorithm: bool
@@ -406,16 +413,16 @@ class LCDMessage(ProtectBaseObject):
 
 
 class TalkbackSettings(ProtectBaseObject):
-    type_fmt: str
+    type_fmt: AudioCodecs
     type_in: str
     bind_addr: IPv4Address
     bind_port: int
-    filter_addr: Optional[str]
-    filter_port: Optional[int]
-    channels: int
-    sampling_rate: int
+    filter_addr: Optional[str]  # can be used to restrict sender address
+    filter_port: Optional[int]  # can be used to restrict sender port
+    channels: int  # 1 or 2
+    sampling_rate: int  # 8000, 11025, 22050, 44100, 48000
     bits_per_sample: int
-    quality: int
+    quality: PercentInt  # only for vorbis
 
 
 class WifiStats(ProtectBaseObject):
@@ -429,7 +436,7 @@ class WifiStats(ProtectBaseObject):
 class BatteryStats(ProtectBaseObject):
     percentage: Optional[PercentInt]
     is_charging: bool
-    sleep_state: str
+    sleep_state: SleepStateType
 
 
 class VideoStats(ProtectBaseObject):
@@ -475,8 +482,15 @@ class VideoStats(ProtectBaseObject):
 
 
 class StorageStats(ProtectBaseObject):
-    used: Optional[int]
-    rate: Optional[float]
+    used: Optional[int]  # bytes
+    rate: Optional[float]  # bytes / millisecond
+
+    @property
+    def rate_per_second(self) -> Optional[float]:
+        if self.rate is None:
+            return None
+
+        return self.rate * 1000
 
     @classmethod
     def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -591,16 +605,16 @@ class FeatureFlags(ProtectBaseObject):
     has_motion_zones: bool
     has_lcd_screen: bool
     smart_detect_types: List[SmartDetectObjectType]
-    motion_algorithms: List[str]
+    motion_algorithms: List[MotionAlgorithm]
     has_square_event_thumbnail: bool
     has_package_camera: bool
     privacy_mask_capability: PrivacyMaskCapability
     has_smart_detect: bool
     audio: List[str] = []
-    audio_codecs: List[str] = []
+    audio_codecs: List[AudioCodecs] = []
+    mount_positions: List[MountPosition] = []
 
     # TODO:
-    # mountPositions
     # focus
     # pan
     # tilt
@@ -670,10 +684,12 @@ class Camera(ProtectMotionDeviceModel):
     is_poor_network: Optional[bool]
     is_wireless_uplink_enabled: Optional[bool]
 
-    # TODO:
+    # TODO: used for adopting
     # apMac
     # apRssi
     # elementInfo
+
+    # TODO:
     # lastPrivacyZonePositionId
     # recordingSchedule
     # smartDetectLines
@@ -1609,7 +1625,7 @@ class Chime(ProtectAdoptableDeviceModel):
     is_wireless_uplink_enabled: bool
     camera_ids: List[str]
 
-    # TODO:
+    # TODO: used for adoption
     # apMac
     # apRssi
     # elementInfo

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -288,7 +288,7 @@ class ISPSettings(ProtectBaseObject):
     touch_focus_x: int
     touch_focus_y: int
     zoom_position: PercentInt
-    mount_position: MountPosition | None = None
+    mount_position: Optional[MountPosition] = None
 
 
 class OSDSettings(ProtectBaseObject):

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -29,17 +29,25 @@ from pyunifiprotect.data.base import (
 )
 from pyunifiprotect.data.devices import Camera, CameraZone, Light, Sensor
 from pyunifiprotect.data.types import (
+    AnalyticsOption,
+    DiskAction,
+    DiskHealth,
+    DiskState,
+    DiskUnsupportedReason,
     DoorbellMessageType,
     DoorbellText,
     EventType,
+    FirmwareReleaseChannel,
     ModelType,
     MountType,
+    PercentFloat,
     PercentInt,
     RecordingType,
     ResolutionStorageType,
     SensorStatusType,
     SensorType,
     SmartDetectObjectType,
+    StorageType,
     Version,
 )
 from pyunifiprotect.exceptions import BadRequest
@@ -327,9 +335,7 @@ class CloudAccount(ProtectModelWithId):
     user_id: str
     name: str
     location: Optional[UserLocation]
-
-    # TODO:
-    # profileImg
+    profile_img: str | None = None
 
     @classmethod
     def _get_unifi_remaps(cls) -> Dict[str, str]:
@@ -343,6 +349,8 @@ class CloudAccount(ProtectModelWithId):
             data["cloudId"] = data["id"]
         if "location" in data and data["location"] is None:
             del data["location"]
+        if "profileImg" in data and data["profileImg"] is None:
+            del data["profileImg"]
 
         return data
 
@@ -460,7 +468,7 @@ class StorageInfo(ProtectBaseObject):
     available: int
     is_recycling: bool
     size: int
-    type: str
+    type: StorageType
     used: int
     devices: List[StorageDevice]
 
@@ -478,14 +486,107 @@ class TMPFSInfo(ProtectBaseObject):
     path: Path
 
 
+class UOSDisk(ProtectBaseObject):
+    slot: int
+    state: DiskState
+
+    type: Literal["SSD", "HDD"] | None = None
+    model: str | None = None
+    serial: str | None = None
+    firmware: str | None = None
+    rpm: int | None = None
+    ata: str | None = None
+    sata: str | None = None
+    action: DiskAction | None = None
+    healthy: DiskHealth | None = None
+    reason: DiskUnsupportedReason | None = None
+    temperature: int | None = None
+    power_on_hours: int | None = None
+    life_span: PercentFloat | None = None
+    bad_sector: int | None = None
+    threshold: int | None = None
+    progress: PercentFloat | None = None
+    estimate: timedelta | None = None
+
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {
+            **super()._get_unifi_remaps(),
+            "poweronhrs": "powerOnHours",
+            "life_span": "lifeSpan",
+            "bad_sector": "badSector",
+        }
+
+    @classmethod
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        if "estimate" in data and data["estimate"] is not None:
+            data["estimate"] = timedelta(seconds=data.pop("estimate"))
+
+        return super().unifi_dict_to_dict(data)
+
+    def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
+        data = super().unifi_dict(data=data, exclude=exclude)
+
+        if "state" in data and data["state"] == "nodisk":
+            delete_keys = [
+                "type",
+                "model",
+                "serial",
+                "firmware",
+                "rpm",
+                "ata",
+                "sata",
+                "action",
+                "healthy",
+                "reason",
+                "tempature",
+                "poweronhrs",
+                "life_span",
+                "bad_sector",
+            ]
+            for key in delete_keys:
+                if key in data:
+                    del data[key]
+
+        return data
+
+
+class UOSSpace(ProtectBaseObject):
+    device: str
+    total_bytes: int
+    used_bytes: int
+    action: DiskAction
+    progress: PercentFloat | None = None
+    estimate: timedelta | None = None
+    healthy: DiskHealth | None = None
+
+    @classmethod
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        if "estimate" in data and data["estimate"] is not None:
+            data["estimate"] = timedelta(seconds=data.pop("estimate"))
+
+        return super().unifi_dict_to_dict(data)
+
+
+class UOSStorage(ProtectBaseObject):
+    disks: list[UOSDisk]
+    space: list[UOSSpace]
+
+
 class SystemInfo(ProtectBaseObject):
     cpu: CPUInfo
     memory: MemoryInfo
     storage: StorageInfo
     tmpfs: TMPFSInfo
+    ustorage: UOSStorage | None = None
 
-    # TODO:
-    # ustorage
+    def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
+        data = super().unifi_dict(data=data, exclude=exclude)
+
+        if data is not None and "ustorage" in data and data["ustorage"] is None:
+            del data["ustorage"]
+
+        return data
 
 
 class DoorbellMessage(ProtectBaseObject):
@@ -613,7 +714,7 @@ class NVR(ProtectDeviceModel):
     is_station: bool
     enable_automatic_backups: bool
     enable_stats_reporting: bool
-    release_channel: str
+    release_channel: FirmwareReleaseChannel
     hosts: List[Union[IPv4Address, str]]
     enable_bridge_auto_adoption: bool
     hardware_id: UUID
@@ -626,7 +727,7 @@ class NVR(ProtectDeviceModel):
     recording_retention_duration: Optional[timedelta]
     enable_crash_reporting: bool
     disable_audio: bool
-    analytics_data: str
+    analytics_data: AnalyticsOption
     anonymous_device_id: UUID
     camera_utilization: int
     is_recycling: bool
@@ -650,13 +751,13 @@ class NVR(ProtectDeviceModel):
     is_db_available: Optional[bool] = None
     is_recording_disabled: Optional[bool] = None
     is_recording_motion_only: Optional[bool] = None
+    ui_version: str | None = None
+    sso_channel: FirmwareReleaseChannel | None = None
 
     # TODO:
-    # uiVersion
     # errorCode
     # wifiSettings
     # smartDetectAgreement
-    # ssoChannel
 
     @classmethod
     def _get_unifi_remaps(cls) -> Dict[str, str]:
@@ -675,6 +776,10 @@ class NVR(ProtectDeviceModel):
 
     async def _api_update(self, data: Dict[str, Any]) -> None:
         return await self.api.update_nvr(data)
+
+    @property
+    def is_analytics_enabled(self) -> bool:
+        return self.analytics_data != AnalyticsOption.NONE
 
     @property
     def protect_url(self) -> str:
@@ -702,6 +807,20 @@ class NVR(ProtectDeviceModel):
             ),
         ]
         self._initial_data = self.dict()
+
+    async def set_analytics(self, value: AnalyticsOption) -> None:
+        """Sets analytics collection for NVR"""
+
+        self.analytics_data = value
+        await self.save_device()
+
+    async def set_anonymous_analytics(self, enabled: bool) -> None:
+        """Enables or disables anonymous analystics for NVR"""
+
+        if enabled:
+            await self.set_analytics(AnalyticsOption.ANONYMOUS)
+        else:
+            await self.set_analytics(AnalyticsOption.NONE)
 
     async def set_default_reset_timeout(self, timeout: timedelta) -> None:
         """Sets the default message reset timeout"""

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -335,7 +335,7 @@ class CloudAccount(ProtectModelWithId):
     user_id: str
     name: str
     location: Optional[UserLocation]
-    profile_img: str | None = None
+    profile_img: Optional[str] = None
 
     @classmethod
     def _get_unifi_remaps(cls) -> Dict[str, str]:
@@ -490,23 +490,23 @@ class UOSDisk(ProtectBaseObject):
     slot: int
     state: DiskState
 
-    type: Literal["SSD", "HDD"] | None = None
-    model: str | None = None
-    serial: str | None = None
-    firmware: str | None = None
-    rpm: int | None = None
-    ata: str | None = None
-    sata: str | None = None
-    action: DiskAction | None = None
-    healthy: DiskHealth | None = None
-    reason: DiskUnsupportedReason | None = None
-    temperature: int | None = None
-    power_on_hours: int | None = None
-    life_span: PercentFloat | None = None
-    bad_sector: int | None = None
-    threshold: int | None = None
-    progress: PercentFloat | None = None
-    estimate: timedelta | None = None
+    type: Optional[Literal["SSD", "HDD"]] = None
+    model: Optional[str] = None
+    serial: Optional[str] = None
+    firmware: Optional[str] = None
+    rpm: Optional[int] = None
+    ata: Optional[str] = None
+    sata: Optional[str] = None
+    action: Optional[DiskAction] = None
+    healthy: Optional[DiskHealth] = None
+    reason: Optional[DiskUnsupportedReason] = None
+    temperature: Optional[int] = None
+    power_on_hours: Optional[int] = None
+    life_span: Optional[PercentFloat] = None
+    bad_sector: Optional[int] = None
+    threshold: Optional[int] = None
+    progress: Optional[PercentFloat] = None
+    estimate: Optional[timedelta] = None
 
     @classmethod
     def _get_unifi_remaps(cls) -> Dict[str, str]:
@@ -556,9 +556,9 @@ class UOSSpace(ProtectBaseObject):
     total_bytes: int
     used_bytes: int
     action: DiskAction
-    progress: PercentFloat | None = None
-    estimate: timedelta | None = None
-    healthy: DiskHealth | None = None
+    progress: Optional[PercentFloat] = None
+    estimate: Optional[timedelta] = None
+    healthy: Optional[DiskHealth] = None
 
     @classmethod
     def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -578,7 +578,7 @@ class SystemInfo(ProtectBaseObject):
     memory: MemoryInfo
     storage: StorageInfo
     tmpfs: TMPFSInfo
-    ustorage: UOSStorage | None = None
+    ustorage: Optional[UOSStorage] = None
 
     def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
         data = super().unifi_dict(data=data, exclude=exclude)
@@ -751,8 +751,8 @@ class NVR(ProtectDeviceModel):
     is_db_available: Optional[bool] = None
     is_recording_disabled: Optional[bool] = None
     is_recording_motion_only: Optional[bool] = None
-    ui_version: str | None = None
-    sso_channel: FirmwareReleaseChannel | None = None
+    ui_version: Optional[str] = None
+    sso_channel: Optional[FirmwareReleaseChannel] = None
 
     # TODO:
     # errorCode

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -185,6 +185,7 @@ class DoorbellMessageType(str, ValuesEnumMixin, enum.Enum):
 class LightModeEnableType(str, ValuesEnumMixin, enum.Enum):
     DARK = "dark"
     ALWAYS = "fulltime"
+    NIGHT = "night"
 
 
 @enum.unique
@@ -192,6 +193,7 @@ class LightModeType(str, ValuesEnumMixin, enum.Enum):
     MOTION = "motion"
     WHEN_DARK = "always"
     MANUAL = "off"
+    SCHEDULE = "schedule"
 
 
 @enum.unique
@@ -207,6 +209,13 @@ class RecordingMode(str, ValuesEnumMixin, enum.Enum):
     ALWAYS = "always"
     NEVER = "never"
     DETECTIONS = "detections"
+
+
+@enum.unique
+class AnalyticsOption(str, ValuesEnumMixin, enum.Enum):
+    NONE = "none"
+    ANONYMOUS = "anonymous"
+    FULL = "full"
 
 
 @enum.unique
@@ -229,6 +238,7 @@ class IRLEDMode(str, ValuesEnumMixin, enum.Enum):
     ON = "on"
     AUTO_NO_LED = "autoFilterOnly"
     OFF = "off"
+    MANUAL = "manual"
 
 
 @enum.unique
@@ -254,6 +264,135 @@ class SensorStatusType(str, ValuesEnumMixin, enum.Enum):
     NEUTRAL = "neutral"
     LOW = "low"
     HIGH = "high"
+
+
+@enum.unique
+class SleepStateType(str, ValuesEnumMixin, enum.Enum):
+    DISCONNECTED = "disconnected"
+    AWAKE = "awake"
+    START_SLEEP = "goingToSleep"
+    ASLEEP = "asleep"
+    WAKING = "waking"
+
+
+@enum.unique
+class AutoExposureMode(str, ValuesEnumMixin, enum.Enum):
+    MANUAL = "manual"
+    AUTO = "auto"
+    SHUTTER = "shutter"
+    FLICK50 = "flick50"
+    FLICK60 = "flick60"
+
+
+@enum.unique
+class FocusMode(str, ValuesEnumMixin, enum.Enum):
+    MANUAL = "manual"
+    AUTO = "auto"
+    ZTRIG = "ztrig"
+    TOUCH = "touch"
+
+
+@enum.unique
+class MountPosition(str, ValuesEnumMixin, enum.Enum):
+    CEILING = "ceiling"
+    WALL = "wall"
+    DESK = "desk"
+
+
+@enum.unique
+class GeofencingSetting(str, ValuesEnumMixin, enum.Enum):
+    OFF = "off"
+    ALL_AWAY = "allAway"
+
+
+@enum.unique
+class MotionAlgorithm(str, ValuesEnumMixin, enum.Enum):
+    STABLE = "stable"
+    ENHANCED = "enhanced"
+
+
+@enum.unique
+class AudioCodecs(str, ValuesEnumMixin, enum.Enum):
+    AAC = "aac"
+    VORBIS = "vorbis"
+    OPUS = "opus"
+
+
+@enum.unique
+class LowMedHigh(str, ValuesEnumMixin, enum.Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+@enum.unique
+class StorageType(str, ValuesEnumMixin, enum.Enum):
+    DISK = "hdd"
+    RAID = "raid"
+    SD_CARD = "sdcard"
+
+
+@enum.unique
+class FirmwareReleaseChannel(str, ValuesEnumMixin, enum.Enum):
+    INTERNAL = "internal"
+    ALPHA = "alpha"
+    BETA = "beta"
+    RELEASE_CANDIDATE = "release-candidate"
+    RELEASE = "release"
+
+
+@enum.unique
+class DiskHealth(str, ValuesEnumMixin, enum.Enum):
+    GOOD = "good"
+    BAD = "risk"
+
+
+@enum.unique
+class DiskAction(str, ValuesEnumMixin, enum.Enum):
+    NONE = "none"
+    FAULTY = "faulty"
+    SPARE = "spare"
+    REPAIRING = "repairing"
+    INTIALIZING = "initializing"
+    EXPANDING = "expanding"
+
+
+@enum.unique
+class DiskState(str, ValuesEnumMixin, enum.Enum):
+    NO_DISK = "nodisk"
+    BROKEN = "broken"
+    BAD = "risk"
+    FAULTY = "faulty"
+    REPAIRING = "repairing"
+    INTIALIZING = "initializing"
+    EXPLANDING = "expanding"
+    FOREIGN = "foreign"
+    SPARE = "spare"
+    NOT_SUPPORTED = "not_support"
+    NORMAL = "normal"
+
+
+@enum.unique
+class DiskUnsupportedReason(str, ValuesEnumMixin, enum.Enum):
+    TYPE = "type"
+    LIMIT = "limit"
+
+
+@enum.unique
+class MountHealth(str, ValuesEnumMixin, enum.Enum):
+    HEALTHY = "health"
+    AT_RISK = "atrisk"
+    FAILED = "failed"
+
+
+@enum.unique
+class MountAction(str, ValuesEnumMixin, enum.Enum):
+    NONE = "none"
+    SYNCING = "syncing"
+    REPAIRING = "repairing"
+    EXPANDING = "expanding"
+    FORMATTING = "formatting"
+    ERASING = "erasing"
 
 
 @enum.unique
@@ -293,6 +432,11 @@ class PercentInt(ConstrainedInt):
     le = 100
 
 
+class TwoByteInt(ConstrainedInt):
+    ge = 1
+    le = 255
+
+
 class PercentFloat(ConstrainedFloat):
     ge = 0
     le = 100
@@ -304,6 +448,11 @@ class ChimeDuration(ConstrainedInt):
 
 
 class WDRLevel(ConstrainedInt):
+    ge = 0
+    le = 3
+
+
+class ICRSensitivity(ConstrainedInt):
     ge = 0
     le = 3
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -513,12 +513,10 @@ def compare_objs(obj_type, expected, actual):
         del expected["smartDetectLines"]
         if "streamSharing" in expected:
             del expected["streamSharing"]
-        del expected["featureFlags"]["mountPositions"]
         del expected["featureFlags"]["focus"]
         del expected["featureFlags"]["pan"]
         del expected["featureFlags"]["tilt"]
         del expected["featureFlags"]["zoom"]
-        del expected["ispSettings"]["mountPosition"]
 
         # do not compare detect zones because float math sucks
         assert len(expected["motionZones"]) == len(actual["motionZones"])

--- a/tests/data/test_common.py
+++ b/tests/data/test_common.py
@@ -164,12 +164,9 @@ def test_bootstrap(bootstrap):
     del bootstrap["schedules"]
     if "deviceGroups" in bootstrap:
         del bootstrap["deviceGroups"]
-    del bootstrap["nvr"]["uiVersion"]
     del bootstrap["nvr"]["errorCode"]
     del bootstrap["nvr"]["wifiSettings"]
-    del bootstrap["nvr"]["ssoChannel"]
     del bootstrap["nvr"]["smartDetectAgreement"]
-    bootstrap["nvr"]["systemInfo"].pop("ustorage", None)
 
     for model_type in ModelType.bootstrap_models():
         key = model_type + "s"

--- a/tests/data/test_nvr.py
+++ b/tests/data/test_nvr.py
@@ -6,10 +6,30 @@ from datetime import timedelta
 from pydantic.error_wrappers import ValidationError
 import pytest
 
-from pyunifiprotect.data import DoorbellMessageType
-from pyunifiprotect.data.nvr import NVR, DoorbellMessage
+from pyunifiprotect.data import (
+    NVR,
+    AnalyticsOption,
+    DoorbellMessage,
+    DoorbellMessageType,
+)
 from pyunifiprotect.exceptions import BadRequest
 from pyunifiprotect.utils import to_ms
+
+
+@pytest.mark.asyncio
+async def test_nvr_set_anonymous_analytics(nvr_obj: NVR):
+    nvr_obj.api.api_request.reset_mock()
+
+    nvr_obj.analytics_data = AnalyticsOption.ANONYMOUS
+    nvr_obj._initial_data = nvr_obj.dict()
+
+    await nvr_obj.set_anonymous_analytics(False)
+
+    nvr_obj.api.api_request.assert_called_with(
+        "nvr",
+        method="patch",
+        json={"analyticsData": "none"},
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -369,8 +369,7 @@ async def test_get_device_not_adopted_enabled(protect_client: ProtectApiClient, 
     protect_client.api_request_obj = AsyncMock(return_value=camera)  # type: ignore
 
     obj = create_from_unifi_dict(camera)
-    new_obj = await protect_client.get_camera("test_id")
-    assert obj == new_obj
+    assert obj == await protect_client.get_camera("test_id")
 
 
 @pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -232,15 +232,12 @@ async def test_get_nvr(protect_client: ProtectApiClient, nvr):
     """Verifies the `get_nvr` method"""
 
     # TODO:
-    del nvr["uiVersion"]
     del nvr["errorCode"]
     del nvr["wifiSettings"]
     del nvr["smartDetectAgreement"]
-    del nvr["ssoChannel"]
     nvr["isDbAvailable"] = nvr.get("isDbAvailable")
     nvr["marketName"] = nvr.get("marketName")
     nvr["streamSharingAvailable"] = nvr.get("streamSharingAvailable")
-    nvr["systemInfo"].pop("ustorage", None)
     nvr["ports"]["piongw"] = nvr["ports"].get("piongw")
 
     nvr_obj = await protect_client.get_nvr()
@@ -372,7 +369,8 @@ async def test_get_device_not_adopted_enabled(protect_client: ProtectApiClient, 
     protect_client.api_request_obj = AsyncMock(return_value=camera)  # type: ignore
 
     obj = create_from_unifi_dict(camera)
-    assert obj == await protect_client.get_camera("test_id")
+    new_obj = await protect_client.get_camera("test_id")
+    assert obj == new_obj
 
 
 @pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")


### PR DESCRIPTION
A bunch of updates from latest version of Protect backend

* Adds helper method/command to change current analytics for the NVR
* Adds a ton of enums for various fields
* Adds `rate_per_second` property for Camera storage stats (the existing value is actually bytes / millisecond)
* Adds support for `ustorage` field on NVR
* Adds missing enum values for `LightModeEnableType` and `LightModeType` (this _may_ be an unexpected change on the HA side)