### PR TITLE
Adds adopt/unadopt CLI

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -70,8 +70,6 @@ _LOGGER = logging.getLogger(__name__)
 # * DELETE /backups/{id} - delete backup
 #
 # Cameras
-# * DELETE /cameras/{id} - delete camera
-# * POST /cameras/{id}/unadopt - unadopt camera
 # * POST /cameras/{id}/reset - factory reset camera
 # * POST /cameras/{id}/reset-isp - reset ISP settings
 # * POST /cameras/{id}/reset-isp - reset ISP settings
@@ -1160,6 +1158,20 @@ class ProtectApiClient(BaseApiClient):
 
         await self.api_request(f"{model_type.value}s/{device_id}/reboot", method="post")
 
+    async def unadopt_device(self, model_type: ModelType, device_id: str) -> None:
+        """Unadopt/Unmanage adopted device"""
+
+        await self.api_request(f"{model_type.value}s/{device_id}", method="delete")
+
+    async def adopt_device(self, model_type: ModelType, device_id: str) -> None:
+        """Adopts a device"""
+
+        key = f"{model_type.value}s"
+        data = await self.api_request_obj("devices/adopt", method="post", json={key: {device_id: {}}})
+
+        if not data.get(key, {}).get(device_id, {}).get("adopted", False):
+            raise BadRequest("Could not adopt device")
+
     async def close_lock(self, device_id: str) -> None:
         """Close doorlock (lock)"""
 
@@ -1169,6 +1181,15 @@ class ProtectApiClient(BaseApiClient):
         """Open doorlock (unlock)"""
 
         await self.api_request(f"doorlocks/{device_id}/open", method="post")
+
+    async def calibrate_lock(self, device_id: str) -> None:
+        """
+        Calibrate the doorlock.
+
+        Door must be open and lock unlocked.
+        """
+
+        await self.api_request(f"doorlocks/{device_id}/calibrate", method="post", json={"auto": True})
 
     async def play_speaker(self, device_id: str) -> None:
         """Plays chime tones on a chime"""

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -95,9 +95,6 @@ _LOGGER = logging.getLogger(__name__)
 # * GET|PATCH|DELETE /device-groups/{id}
 # * PATCH /device-groups/{id}/items
 #
-# Doorlocks
-# POST /doorlocks/{id}/calibrate
-#
 # Events
 # POST /events/{id}/animated-thumbnail
 #

--- a/pyunifiprotect/cli/__init__.py
+++ b/pyunifiprotect/cli/__init__.py
@@ -77,6 +77,7 @@ OPTION_OUT_FORMAT = typer.Option(
     help="Output format for commands. Not all commands support plain and will still output in JSON.",
 )
 OPTION_WS_FILE = typer.Option(None, "--file", "-f", help="Path or raw binary Websocket message")
+OPTION_UNADOPTED = typer.Option(False, "-u", "--include-unadopted", help="Include devices not adopted by this NVR")
 ARG_WS_DATA = typer.Argument(None, help="base64 encoded Websocket message")
 
 SLEEP_INTERVAL = 2
@@ -102,10 +103,13 @@ def main(
     port: int = OPTION_PORT,
     verify: bool = OPTION_VERIFY,
     output_format: OutputFormatEnum = OPTION_OUT_FORMAT,
+    include_unadopted: bool = OPTION_UNADOPTED,
 ) -> None:
     """UniFi Protect CLI"""
 
-    protect = ProtectApiClient(address, port, username, password, verify_ssl=verify)
+    protect = ProtectApiClient(
+        address, port, username, password, verify_ssl=verify, ignore_unadopted=not include_unadopted
+    )
 
     async def update() -> None:
         protect._bootstrap = await protect.get_bootstrap()  # pylint: disable=protected-access

--- a/pyunifiprotect/cli/base.py
+++ b/pyunifiprotect/cli/base.py
@@ -217,7 +217,7 @@ def adopt(ctx: typer.Context, name: Optional[str] = typer.Argument(None)) -> Non
     Adopts a device.
 
     By default, unadopted devices do not show up in the bootstrap. Use
-    `unifi-protect -d` to show unadopted devices.
+    `unifi-protect -u` to show unadopted devices.
     """
 
     require_device_id(ctx)

--- a/pyunifiprotect/cli/base.py
+++ b/pyunifiprotect/cli/base.py
@@ -15,6 +15,8 @@ from pyunifiprotect.exceptions import BadRequest, StreamError
 
 T = TypeVar("T")
 
+OPTION_FORCE = typer.Option(False, "-f", "--force", help="Skip confirmation prompt")
+
 
 class OutputFormatEnum(str, Enum):
     JSON = "json"
@@ -93,7 +95,21 @@ def list_ids(ctx: typer.Context) -> None:
     objs: dict[str, ProtectAdoptableDeviceModel] = ctx.obj.devices
     to_print: list[tuple[str, str | None]] = []
     for obj in objs.values():
-        to_print.append((obj.id, obj.name))
+        name = obj.name
+        if obj.is_adopted_by_other:
+            name = f"{name} [Managed by Another Console]"
+        elif obj.is_adopting:
+            name = f"{name} [Adopting]"
+        elif obj.can_adopt:
+            name = f"{name} [Unadopted]"
+        elif obj.is_rebooting:
+            name = f"{name} [Restarting]"
+        elif obj.is_updating:
+            name = f"{name} [Updating]"
+        elif not obj.is_connected:
+            name = f"{name} [Disconnected]"
+
+        to_print.append((obj.id, name))
 
     if ctx.obj.output_format == OutputFormatEnum.JSON:
         json_output(to_print)
@@ -176,13 +192,33 @@ def update(ctx: typer.Context, data: str) -> None:
         run(ctx, obj.api.update_device(obj.model, obj.id, json.loads(data)))
 
 
-def reboot(ctx: typer.Context) -> None:
+def reboot(ctx: typer.Context, force: bool = OPTION_FORCE) -> None:
     """Reboots the device."""
 
     require_device_id(ctx)
     obj: NVR | ProtectAdoptableDeviceModel = ctx.obj.device
 
-    run(ctx, obj.reboot())
+    if force or typer.confirm(f'Confirm reboot of "{obj.name}"" (id: {obj.id})'):
+        run(ctx, obj.reboot())
+
+
+def unadopt(ctx: typer.Context, force: bool = OPTION_FORCE) -> None:
+    """Unadopt/Unmanage adopted device"""
+
+    require_device_id(ctx)
+    obj: ProtectAdoptableDeviceModel = ctx.obj.device
+
+    if force or typer.confirm(f'Confirm undopt of "{obj.name}"" (id: {obj.id})'):
+        run(ctx, obj.unadopt())
+
+
+def adopt(ctx: typer.Context, name: Optional[str] = typer.Argument(None)) -> None:
+    """Adopts a device"""
+
+    require_device_id(ctx)
+    obj: ProtectAdoptableDeviceModel = ctx.obj.device
+
+    run(ctx, obj.adopt(name))
 
 
 def init_common_commands(app: typer.Typer) -> tuple[dict[str, Callable[..., Any]], dict[str, Callable[..., Any]]]:
@@ -199,5 +235,7 @@ def init_common_commands(app: typer.Typer) -> tuple[dict[str, Callable[..., Any]
     device_commands["set-name"] = app.command()(set_name)
     device_commands["update"] = app.command()(update)
     device_commands["reboot"] = app.command()(reboot)
+    device_commands["unadopt"] = app.command()(unadopt)
+    device_commands["adopt"] = app.command()(adopt)
 
     return deviceless_commands, device_commands

--- a/pyunifiprotect/cli/base.py
+++ b/pyunifiprotect/cli/base.py
@@ -213,7 +213,12 @@ def unadopt(ctx: typer.Context, force: bool = OPTION_FORCE) -> None:
 
 
 def adopt(ctx: typer.Context, name: Optional[str] = typer.Argument(None)) -> None:
-    """Adopts a device"""
+    """
+    Adopts a device.
+
+    By default, unadopted devices do not show up in the bootstrap. Use
+    `unifi-protect -d` to show unadopted devices.
+    """
 
     require_device_id(ctx)
     obj: ProtectAdoptableDeviceModel = ctx.obj.device

--- a/pyunifiprotect/cli/doorlocks.py
+++ b/pyunifiprotect/cli/doorlocks.py
@@ -109,3 +109,18 @@ def lock(ctx: typer.Context) -> None:
     base.require_device_id(ctx)
     obj: Doorlock = ctx.obj.device
     base.run(ctx, obj.close_lock())
+
+
+@app.command()
+def calibrate(ctx: typer.Context, force: bool = base.OPTION_FORCE) -> None:
+    """
+    Calibrate the doorlock.
+
+    Door must be open and lock unlocked.
+    """
+
+    base.require_device_id(ctx)
+    obj: Doorlock = ctx.obj.device
+
+    if force or typer.confirm("Is the door open and unlocked?"):
+        base.run(ctx, obj.calibrate())

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -744,6 +744,26 @@ class ProtectAdoptableDeviceModel(ProtectDeviceModel):
         if self.model is not None:
             await self.api.reboot_device(self.model, self.id)
 
+    async def unadopt(self) -> None:
+        """Unadopt/Unmanage adopted device"""
+
+        if not self.is_adopted:
+            raise BadRequest("Device is not adopted")
+
+        if self.model is not None:
+            await self.api.unadopt_device(self.model, self.id)
+
+    async def adopt(self, name: Optional[str]) -> None:
+        """Adopts a device"""
+
+        if not self.can_adopt:
+            raise BadRequest("Device cannot be adopted")
+
+        if self.model is not None:
+            await self.api.adopt_device(self.model, self.id)
+            if name is not None:
+                await self.set_name(name)
+
 
 class ProtectMotionDeviceModel(ProtectAdoptableDeviceModel):
     last_motion: Optional[datetime]

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -1654,6 +1654,15 @@ class Doorlock(ProtectAdoptableDeviceModel):
 
         await self.api.open_lock(self.id)
 
+    async def calibrate(self) -> None:
+        """
+        Calibrate the doorlock.
+
+        Door must be open and lock unlocked.
+        """
+
+        await self.api.calibrate_lock(self.id)
+
 
 class Chime(ProtectAdoptableDeviceModel):
     volume: PercentInt


### PR DESCRIPTION
More CLI improvements from me trying to get the HomeKit functionality of the Door lock working (no luck).

* Adds CLI option to show unadopted devices
* Adds helper methods/CLI commands for adopting and unadopting devices
* Adds helper method and CLI command for calibrating Doorlocks
* Adds extra status text to `list-ids` if the device is in a special state
* Adds confirmation to rebooting devices via CLI