### PR TITLE
Updates from UniFi Protect 2.1.1

### DIFF
--- a/pyunifiprotect/cli/base.py
+++ b/pyunifiprotect/cli/base.py
@@ -95,7 +95,7 @@ def list_ids(ctx: typer.Context) -> None:
     objs: dict[str, ProtectAdoptableDeviceModel] = ctx.obj.devices
     to_print: list[tuple[str, str | None]] = []
     for obj in objs.values():
-        name = obj.name
+        name = obj.name or obj.market_name or obj.type
         if obj.is_adopted_by_other:
             name = f"{name} [Managed by Another Console]"
         elif obj.is_adopting:

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -619,12 +619,15 @@ class FeatureFlags(ProtectBaseObject):
     audio: List[str] = []
     audio_codecs: List[AudioCodecs] = []
     mount_positions: List[MountPosition] = []
+    has_infrared: Optional[bool] = None
 
     # TODO:
     # focus
     # pan
     # tilt
     # zoom
+    # lensType
+    # hotplug
 
     @classmethod
     def _get_unifi_remaps(cls) -> Dict[str, str]:
@@ -1297,6 +1300,7 @@ class Viewer(ProtectAdoptableDeviceModel):
     stream_limit: int
     software_version: str
     liveview_id: str
+    anonymous_device_id: Optional[UUID] = None
 
     @classmethod
     def _get_unifi_remaps(cls) -> Dict[str, str]:

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -449,6 +449,8 @@ class PortConfig(ProtectBaseObject):
     ucore: int
     discovery_client: int
     piongw: Optional[int] = None
+    ems_json_cli: Optional[int] = None
+    stacking: Optional[int] = None
 
     @classmethod
     def _get_unifi_remaps(cls) -> Dict[str, str]:
@@ -456,6 +458,7 @@ class PortConfig(ProtectBaseObject):
             **super()._get_unifi_remaps(),
             "emsCLI": "emsCli",
             "emsLiveFLV": "emsLiveFlv",
+            "emsJsonCLI": "emsJsonCli",
         }
 
 
@@ -800,6 +803,9 @@ class NVR(ProtectDeviceModel):
     is_recording_motion_only: Optional[bool] = None
     ui_version: Optional[str] = None
     sso_channel: Optional[FirmwareReleaseChannel] = None
+    is_stacked: Optional[bool] = None
+    is_primary: Optional[bool] = None
+    last_drive_slow_event: Optional[datetime] = None
 
     # TODO:
     # errorCode   read only

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -223,6 +223,7 @@ class LightModeType(str, ValuesEnumMixin, enum.Enum):
 class VideoMode(str, ValuesEnumMixin, enum.Enum):
     DEFAULT = "default"
     HIGH_FPS = "highFps"
+    HOMEKIT = "homekit"
     # should only be for unadopted devices
     UNKNOWN = "unknown"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -494,6 +494,11 @@ NEW_FIELDS = {
     "isDbAvailable",
     "isRecordingDisabled",
     "isRecordingMotionOnly",
+    # 2.1.1-beta3
+    "anonymousDeviceId",  # added to viewport
+    "isStacked",
+    "isPrimary",
+    "lastDriveSlowEvent",
 }
 
 
@@ -514,6 +519,10 @@ def compare_objs(obj_type, expected, actual):
         del expected["smartDetectLines"]
         if "streamSharing" in expected:
             del expected["streamSharing"]
+        if "hotplug" in expected["featureFlags"]:
+            del expected["featureFlags"]["hotplug"]
+        if "lensType" in expected["featureFlags"]:
+            del expected["featureFlags"]["lensType"]
         del expected["featureFlags"]["focus"]
         del expected["featureFlags"]["pan"]
         del expected["featureFlags"]["tilt"]
@@ -532,6 +541,7 @@ def compare_objs(obj_type, expected, actual):
         )
         expected["featureFlags"]["audio"] = expected["featureFlags"].get("audio", [])
         expected["featureFlags"]["audioCodecs"] = expected["featureFlags"].get("audioCodecs", [])
+        expected["featureFlags"]["hasInfrared"] = expected["featureFlags"].get("hasInfrared")
     elif obj_type == ModelType.USER.value:
         if "settings" in expected:
             expected.pop("settings", None)
@@ -567,6 +577,8 @@ def compare_objs(obj_type, expected, actual):
         expected["marketName"] = expected.get("marketName")
         expected["streamSharingAvailable"] = expected.get("streamSharingAvailable")
         expected["ports"]["piongw"] = expected["ports"].get("piongw")
+        expected["ports"]["stacking"] = expected["ports"].get("stacking")
+        expected["ports"]["emsJsonCLI"] = expected["ports"].get("emsJsonCLI")
 
         # float math...
         if expected["systemInfo"].get("ustorage") is not None:


### PR DESCRIPTION
Nothing really new. Just updates from the new version. 

Also added fallback for display name for the `list-ids` command if the object has no name.