### PR TITLE
Adds full handling of permissions

### DIFF
--- a/pyunifiprotect/data/__init__.py
+++ b/pyunifiprotect/data/__init__.py
@@ -20,16 +20,12 @@ from pyunifiprotect.data.devices import (
 )
 from pyunifiprotect.data.nvr import (
     NVR,
-    CloudAccount,
     DoorbellMessage,
     Event,
-    Group,
     Liveview,
     NVRLocation,
     SmartDetectItem,
     SmartDetectTrack,
-    User,
-    UserLocation,
 )
 from pyunifiprotect.data.types import (
     DEFAULT,
@@ -50,6 +46,7 @@ from pyunifiprotect.data.types import (
     ModelType,
     MountType,
     Percent,
+    PermissionNode,
     ProtectWSPayloadFormat,
     RecordingMode,
     SensorStatusType,
@@ -60,6 +57,7 @@ from pyunifiprotect.data.types import (
     VideoMode,
     WDRLevel,
 )
+from pyunifiprotect.data.user import CloudAccount, Group, Permission, User, UserLocation
 from pyunifiprotect.data.websocket import (
     WS_HEADER_SIZE,
     WSAction,
@@ -105,6 +103,8 @@ __all__ = [
     "NVR",
     "NVRLocation",
     "Percent",
+    "Permission",
+    "PermissionNode",
     "ProtectAdoptableDeviceModel",
     "ProtectBaseObject",
     "ProtectDeviceModel",

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -24,6 +24,7 @@ from pydantic.fields import SHAPE_DICT, SHAPE_LIST, PrivateAttr
 from pyunifiprotect.data.types import (
     ModelType,
     PercentFloat,
+    PermissionNode,
     ProtectWSPayloadFormat,
     StateType,
 )
@@ -48,6 +49,7 @@ if TYPE_CHECKING:
     from pyunifiprotect.api import ProtectApiClient
     from pyunifiprotect.data.devices import Bridge
     from pyunifiprotect.data.nvr import Event
+    from pyunifiprotect.data.user import User
 
 
 ProtectObject = TypeVar("ProtectObject", bound="ProtectBaseObject")
@@ -526,6 +528,30 @@ class ProtectModel(ProtectBaseObject):
             del data["modelKey"]
 
         return data
+
+    def can_create(self, user: User) -> bool:
+        if self.model is None:
+            return True
+
+        return user.can(self.model, PermissionNode.CREATE, self)
+
+    def can_read(self, user: User) -> bool:
+        if self.model is None:
+            return True
+
+        return user.can(self.model, PermissionNode.READ, self)
+
+    def can_write(self, user: User) -> bool:
+        if self.model is None:
+            return True
+
+        return user.can(self.model, PermissionNode.WRITE, self)
+
+    def can_delete(self, user: User) -> bool:
+        if self.model is None:
+            return True
+
+        return user.can(self.model, PermissionNode.DELETE, self)
 
 
 class ProtectModelWithId(ProtectModel):

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -27,8 +27,9 @@ from pyunifiprotect.data.devices import (
     Sensor,
     Viewer,
 )
-from pyunifiprotect.data.nvr import NVR, Event, Group, Liveview, User
+from pyunifiprotect.data.nvr import NVR, Event, Liveview
 from pyunifiprotect.data.types import EventType, FixSizeOrderedDict, ModelType
+from pyunifiprotect.data.user import Group, User
 from pyunifiprotect.data.websocket import (
     WSAction,
     WSJSONPacketFrame,

--- a/pyunifiprotect/data/convert.py
+++ b/pyunifiprotect/data/convert.py
@@ -4,16 +4,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 
 from pyunifiprotect.data.devices import Bridge, Camera, Doorlock, Light, Sensor, Viewer
-from pyunifiprotect.data.nvr import (
-    NVR,
-    CloudAccount,
-    Event,
-    Group,
-    Liveview,
-    User,
-    UserLocation,
-)
+from pyunifiprotect.data.nvr import NVR, Event, Liveview
 from pyunifiprotect.data.types import ModelType
+from pyunifiprotect.data.user import CloudAccount, Group, User, UserLocation
 from pyunifiprotect.exceptions import DataDecodeError
 
 if TYPE_CHECKING:

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -41,6 +41,7 @@ from pyunifiprotect.data.types import (
     MountType,
     Percent,
     PercentInt,
+    PermissionNode,
     ProgressCallback,
     RecordingMode,
     SensorStatusType,
@@ -50,6 +51,7 @@ from pyunifiprotect.data.types import (
     VideoMode,
     WDRLevel,
 )
+from pyunifiprotect.data.user import User
 from pyunifiprotect.exceptions import BadRequest, StreamError
 from pyunifiprotect.stream import TalkbackStream
 from pyunifiprotect.utils import (
@@ -1294,6 +1296,18 @@ class Camera(ProtectMotionDeviceModel):
             raise StreamError("No audio playing to stop")
 
         await stream.stop()
+
+    def can_read_media(self, user: User) -> bool:
+        if self.model is None:
+            return True
+
+        return user.can(self.model, PermissionNode.READ_MEDIA, self)
+
+    def can_delete_media(self, user: User) -> bool:
+        if self.model is None:
+            return True
+
+        return user.can(self.model, PermissionNode.DELETE_MEDIA, self)
 
 
 class Viewer(ProtectAdoptableDeviceModel):

--- a/pyunifiprotect/data/types.py
+++ b/pyunifiprotect/data/types.py
@@ -84,6 +84,7 @@ class ModelType(str, ValuesEnumMixin, enum.Enum):
     SCHEDULE = "schedule"
     CHIME = "chime"
     DEVICE_GROUP = "deviceGroup"
+    LEGACY_UFV = "legacyUFV"
 
     @staticmethod
     def bootstrap_models() -> List[str]:
@@ -386,6 +387,16 @@ class LockStatusType(str, ValuesEnumMixin, enum.Enum):
     AUTO_CALIBRATION_IN_PROGRESS = "AUTO_CALIBRATION_IN_PROGRESS"
     CALIBRATION_WAITING_OPEN = "CALIBRATION_WAITING_OPEN"
     CALIBRATION_WAITING_CLOSE = "CALIBRATION_WAITING_CLOSE"
+
+
+@enum.unique
+class PermissionNode(str, enum.Enum):
+    CREATE = "create"
+    READ = "read"
+    WRITE = "write"
+    DELETE = "delete"
+    READ_MEDIA = "readmedia"
+    DELETE_MEDIA = "deletemedia"
 
 
 class DoorbellText(ConstrainedStr):

--- a/pyunifiprotect/data/user.py
+++ b/pyunifiprotect/data/user.py
@@ -184,12 +184,13 @@ class User(ProtectModelWithId):
             return self._perm_cache[perm_str]
 
         for perm in self.all_permissions:
-            if model == perm.model and node in perm.nodes:
-                if perm.obj_id is None:
-                    self._perm_cache[perm_str] = True
-                    return True
-                if perm.obj_id is not None and perm.obj == obj:
-                    self._perm_cache[perm_str] = True
-                    return True
+            if model != perm.model or node not in perm.nodes:
+                continue
+            if perm.obj_id is None:
+                self._perm_cache[perm_str] = True
+                return True
+            if perm.obj_id is not None and perm.obj == obj:
+                self._perm_cache[perm_str] = True
+                return True
         self._perm_cache[perm_str] = False
         return False

--- a/pyunifiprotect/data/user.py
+++ b/pyunifiprotect/data/user.py
@@ -1,0 +1,195 @@
+"""UniFi Protect User models."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set, cast
+
+from pydantic.fields import PrivateAttr
+
+from pyunifiprotect.data.base import ProtectBaseObject, ProtectModel, ProtectModelWithId
+from pyunifiprotect.data.types import ModelType, PermissionNode
+
+
+class Permission(ProtectBaseObject):
+    raw_permission: str
+    model: ModelType
+    nodes: Set[PermissionNode]
+    obj_id: Optional[str]
+
+    @classmethod
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        permission = data.get("rawPermission", "")
+        parts = permission.split(":")
+        if len(parts) < 2:
+            raise ValueError(f"Invalid permission: {permission}")
+
+        data["model"] = ModelType(parts[0])
+        if parts[1] == "*":
+            data["nodes"] = list(PermissionNode)
+        else:
+            data["nodes"] = [PermissionNode(n) for n in parts[1].split(",")]
+
+        if len(parts) == 3 and parts[2] != "*" and parts[2] != "$":
+            data["obj_id"] = parts[2]
+
+        return super().unifi_dict_to_dict(data)
+
+    def unifi_dict(  # type: ignore
+        self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None
+    ) -> str:
+        return self.raw_permission
+
+    @property
+    def obj(self) -> Optional[ProtectModel]:
+        if self.obj_id is None:
+            return None
+
+        devices = getattr(self.api.bootstrap, f"{self.model.value}s")
+        return cast(Optional[ProtectModel], devices.get(self.obj_id))
+
+
+class Group(ProtectModelWithId):
+    name: str
+    permissions: List[Permission]
+    type: str
+    is_default: bool
+
+    @classmethod
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        if "permissions" in data:
+            permissions = data.pop("permissions")
+            data["permissions"] = [{"rawPermission": p} for p in permissions]
+
+        return super().unifi_dict_to_dict(data)
+
+
+class UserLocation(ProtectModel):
+    is_away: bool
+    latitude: Optional[float]
+    longitude: Optional[float]
+
+
+class CloudAccount(ProtectModelWithId):
+    first_name: str
+    last_name: str
+    email: str
+    user_id: str
+    name: str
+    location: Optional[UserLocation]
+    profile_img: Optional[str] = None
+
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "user": "userId"}
+
+    def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
+        data = super().unifi_dict(data=data, exclude=exclude)
+
+        # id and cloud ID are always the same
+        if "id" in data:
+            data["cloudId"] = data["id"]
+        if "location" in data and data["location"] is None:
+            del data["location"]
+
+        return data
+
+    @property
+    def user(self) -> User:
+        return self.api.bootstrap.users[self.user_id]
+
+
+class UserFeatureFlags(ProtectBaseObject):
+    notifications_v2: bool
+
+
+class User(ProtectModelWithId):
+    permissions: List[Permission]
+    last_login_ip: Optional[str]
+    last_login_time: Optional[datetime]
+    is_owner: bool
+    enable_notifications: bool
+    has_accepted_invite: bool
+    all_permissions: List[Permission]
+    scopes: Optional[List[str]] = None
+    location: Optional[UserLocation]
+    name: str
+    first_name: str
+    last_name: str
+    email: str
+    local_username: str
+    group_ids: List[str]
+    cloud_account: Optional[CloudAccount]
+    feature_flags: UserFeatureFlags
+
+    # TODO:
+    # settings
+    # alertRules
+    # notificationsV2
+
+    _groups: Optional[List[Group]] = PrivateAttr(None)
+    _perm_cache: Dict[str, bool] = PrivateAttr({})
+
+    def __init__(self, **data: Any) -> None:
+        if "permissions" in data:
+            permissions = data.pop("permissions")
+            data["permissions"] = [{"raw_permission": p} if isinstance(p, str) else p for p in permissions]
+        if "allPermissions" in data:
+            permissions = data.pop("allPermissions")
+            data["allPermissions"] = [{"raw_permission": p} if isinstance(p, str) else p for p in permissions]
+
+        super().__init__(**data)
+
+    @classmethod
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        if "permissions" in data:
+            permissions = data.pop("permissions")
+            data["permissions"] = [{"rawPermission": p} for p in permissions]
+        if "allPermissions" in data:
+            permissions = data.pop("allPermissions")
+            data["allPermissions"] = [{"rawPermission": p} for p in permissions]
+
+        return super().unifi_dict_to_dict(data)
+
+    @classmethod
+    def _get_unifi_remaps(cls) -> Dict[str, str]:
+        return {**super()._get_unifi_remaps(), "groups": "groupIds"}
+
+    def unifi_dict(self, data: Optional[Dict[str, Any]] = None, exclude: Optional[Set[str]] = None) -> Dict[str, Any]:
+        data = super().unifi_dict(data=data, exclude=exclude)
+
+        if "location" in data and data["location"] is None:
+            del data["location"]
+
+        return data
+
+    @property
+    def groups(self) -> List[Group]:
+        """
+        Groups the user is in
+
+        Will always be empty if the user only has read only access.
+        """
+
+        if self._groups is not None:
+            return self._groups
+
+        self._groups = [self.api.bootstrap.groups[g] for g in self.group_ids if g in self.api.bootstrap.groups]
+        return self._groups
+
+    def can(self, model: ModelType, node: PermissionNode, obj: Optional[ProtectModel] = None) -> bool:
+        """Checks if a user can do a specific action"""
+
+        perm_str = f"{model.value}:{node.value}:{obj if obj is not None else '*'}"
+        if perm_str in self._perm_cache:
+            return self._perm_cache[perm_str]
+
+        for perm in self.all_permissions:
+            if model == perm.model and node in perm.nodes:
+                if perm.obj_id is None:
+                    self._perm_cache[perm_str] = True
+                    return True
+                if perm.obj_id is not None and perm.obj == obj:
+                    self._perm_cache[perm_str] = True
+                    return True
+        self._perm_cache[perm_str] = False
+        return False

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -32,7 +32,7 @@ from typing import (
 from uuid import UUID
 
 from aiohttp import ClientResponse
-from pydantic.fields import SHAPE_DICT, SHAPE_LIST, ModelField
+from pydantic.fields import SHAPE_DICT, SHAPE_LIST, SHAPE_SET, ModelField
 from pydantic.utils import to_camel
 
 from pyunifiprotect.data.types import Version
@@ -167,6 +167,8 @@ def convert_unifi_data(value: Any, field: ModelField) -> Any:
 
     if field.shape == SHAPE_LIST and isinstance(value, list):
         value = [convert_unifi_data(v, field) for v in value]
+    elif field.shape == SHAPE_SET and isinstance(value, list):
+        value = {convert_unifi_data(v, field) for v in value}
     elif field.shape == SHAPE_DICT and isinstance(value, dict):
         value = {k: convert_unifi_data(v, field) for k, v in value.items()}
     elif field.type_ in (Union[IPv4Address, str, None], Union[IPv4Address, str]) and value is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,6 +303,11 @@ async def liveview_obj(protect_client: ProtectApiClient):
     return list(protect_client.bootstrap.liveviews.values())[0]
 
 
+@pytest_asyncio.fixture
+async def user_obj(protect_client: ProtectApiClient):
+    return protect_client.bootstrap.auth_user
+
+
 @pytest.fixture
 def liveview():
     if not TEST_LIVEVIEW_EXISTS:


### PR DESCRIPTION
* Adds `Permission` model to parse permission strings from UniFi Protect
* Adds `can` method to user
* Adds `can_*` helper methods to Protect models to check permissions
* Splits all user related models into its own file, only the marked code sections are new for the `user.py`, the rest are moved from the old file.

Next PR will be to integrate the permissions into other locations/methods.