### PR TITLE
Adds permission checking to various methods

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -264,6 +264,8 @@ class BaseApiClient:
                 if raise_exception:
                     if response.status in (401, 403):
                         raise NotAuthorized(msg % (url, response.status, reason))
+                    if response.status >= 400 and response.status < 500:
+                        raise BadRequest(msg % (url, response.status, reason))
                     raise NvrError(msg % (url, response.status, reason))
                 _LOGGER.debug(msg, url, response.status, reason)
                 return None

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -36,6 +36,7 @@ from pyunifiprotect.data.types import (
     LightModeType,
     LockStatusType,
     LowMedHigh,
+    ModelType,
     MotionAlgorithm,
     MountPosition,
     MountType,
@@ -52,7 +53,7 @@ from pyunifiprotect.data.types import (
     WDRLevel,
 )
 from pyunifiprotect.data.user import User
-from pyunifiprotect.exceptions import BadRequest, StreamError
+from pyunifiprotect.exceptions import BadRequest, NotAuthorized, StreamError
 from pyunifiprotect.stream import TalkbackStream
 from pyunifiprotect.utils import (
     from_js_time,
@@ -955,6 +956,9 @@ class Camera(ProtectMotionDeviceModel):
         Datetime of screenshot is approximate. It may be +/- a few seconds.
         """
 
+        if not self.api.bootstrap.auth_user.can(ModelType.CAMERA, PermissionNode.READ_MEDIA, self):
+            raise NotAuthorized(f"Do not have permission to read media for camera: {self.id}")
+
         return await self.api.get_camera_snapshot(self.id, width, height, dt=dt)
 
     async def get_package_snapshot(
@@ -972,6 +976,9 @@ class Camera(ProtectMotionDeviceModel):
         if not self.feature_flags.has_package_camera:
             raise BadRequest("Device does not have package camera")
 
+        if not self.api.bootstrap.auth_user.can(ModelType.CAMERA, PermissionNode.READ_MEDIA, self):
+            raise NotAuthorized(f"Do not have permission to read media for camera: {self.id}")
+
         return await self.api.get_package_camera_snapshot(self.id, width, height, dt=dt)
 
     async def get_video(
@@ -985,6 +992,9 @@ class Camera(ProtectMotionDeviceModel):
         chunk_size: int = 65536,
     ) -> Optional[bytes]:
         """Gets video clip for camera at a given time"""
+
+        if not self.api.bootstrap.auth_user.can(ModelType.CAMERA, PermissionNode.READ_MEDIA, self):
+            raise NotAuthorized(f"Do not have permission to read media for camera: {self.id}")
 
         return await self.api.get_camera_video(
             self.id,
@@ -1643,6 +1653,8 @@ class Sensor(ProtectAdoptableDeviceModel):
     async def clear_tamper(self) -> None:
         """Clears tamper status for sensor"""
 
+        if not self.api.bootstrap.auth_user.can(ModelType.SENSOR, PermissionNode.WRITE, self):
+            raise NotAuthorized(f"Do not have permission to clear tamper for sensor: {self.id}")
         await self.api.clear_tamper_sensor(self.id)
 
 

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -38,6 +38,7 @@ from pyunifiprotect.data.types import (
     MountType,
     PercentFloat,
     PercentInt,
+    PermissionNode,
     ProgressCallback,
     RecordingType,
     ResolutionStorageType,
@@ -48,7 +49,7 @@ from pyunifiprotect.data.types import (
     Version,
 )
 from pyunifiprotect.data.user import User, UserLocation
-from pyunifiprotect.exceptions import BadRequest
+from pyunifiprotect.exceptions import BadRequest, NotAuthorized
 from pyunifiprotect.utils import process_datetime
 
 if TYPE_CHECKING:
@@ -254,6 +255,8 @@ class Event(ProtectModelWithId):
 
         if self.thumbnail_id is None:
             return None
+        if not self.api.bootstrap.auth_user.can(ModelType.CAMERA, PermissionNode.READ_MEDIA, self.camera):
+            raise NotAuthorized(f"Do not have permission to read media for camera: {self.id}")
         return await self.api.get_event_thumbnail(self.thumbnail_id, width, height)
 
     async def get_heatmap(self) -> Optional[bytes]:
@@ -261,6 +264,8 @@ class Event(ProtectModelWithId):
 
         if self.heatmap_id is None:
             return None
+        if not self.api.bootstrap.auth_user.can(ModelType.CAMERA, PermissionNode.READ_MEDIA, self.camera):
+            raise NotAuthorized(f"Do not have permission to read media for camera: {self.id}")
         return await self.api.get_event_heatmap(self.heatmap_id)
 
     async def get_video(
@@ -285,6 +290,8 @@ class Event(ProtectModelWithId):
         if self.end is None:
             raise BadRequest("Event is ongoing")
 
+        if not self.api.bootstrap.auth_user.can(ModelType.CAMERA, PermissionNode.READ_MEDIA, self.camera):
+            raise NotAuthorized(f"Do not have permission to read media for camera: {self.id}")
         return await self.api.get_camera_video(
             self.camera.id,
             self.start,

--- a/pyunifiprotect/exceptions.py
+++ b/pyunifiprotect/exceptions.py
@@ -30,8 +30,8 @@ class Invalid(ClientError):
     """Invalid return from Authorization Request."""
 
 
-class NotAuthorized(ClientError):
-    """Wrong username and/or Password."""
+class NotAuthorized(PermissionError, BadRequest):
+    """Wrong username, password or permission error."""
 
 
 class NvrError(ClientError):


### PR DESCRIPTION
* Adds `BadRequest` to making API requests
* Adds `revert_changes` method to base ProtectModel, will revert any unsaved changes to the model
* Updates `save_device` to automatically revert any changes made to the device if there was an error saving
* Adds permissions checks to various applicable places
    * Not a breaking change these without this check, it would have raised a `NotAuthorized` error on trying to make the network request. The error has just been moved up to before the network request.