### PR TITLE
Cleans up WS logging. Adds support for remove WS messages

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,7 @@
             "request": "launch",
             "module": "pyunifiprotect",
             "args": [
+                "-u",
                 "shell",
             ]
         },

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -595,7 +595,6 @@ class ProtectApiClient(BaseApiClient):
         return self._bootstrap.last_update_id
 
     def _process_ws_message(self, msg: aiohttp.WSMessage) -> None:
-        _LOGGER.debug("Processing WS message...")
         packet = WSPacket(msg.data)
         processed_message = self.bootstrap.process_ws_packet(
             packet, models=self._subscribed_models, ignore_stats=self._ignore_stats

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -718,7 +718,7 @@ class WifiConnectionState(WirelessConnectionState):
 
 class ProtectAdoptableDeviceModel(ProtectDeviceModel):
     state: StateType
-    connection_host: Union[IPv4Address, str]
+    connection_host: Union[IPv4Address, str, None]
     connected_since: Optional[datetime]
     latest_firmware_version: Optional[str]
     firmware_build: Optional[str]

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -214,6 +214,10 @@ class EventStats(ProtectBaseObject):
 
         if "recent_hours" not in data:
             data["recent_hours"] = []
+        else:
+            recent = data["recent_hours"]
+            if len(recent) == 1 and recent[0] is None:
+                data["recent_hours"] = []
 
         return data
 
@@ -294,8 +298,8 @@ class ISPSettings(ProtectBaseObject):
     d_zoom_stream_id: int
     focus_mode: FocusMode
     focus_position: int
-    touch_focus_x: int
-    touch_focus_y: int
+    touch_focus_x: Optional[int]
+    touch_focus_y: Optional[int]
     zoom_position: PercentInt
     mount_position: Optional[MountPosition] = None
 
@@ -581,7 +585,7 @@ class SmartMotionZone(MotionZone):
 
 
 class PrivacyMaskCapability(ProtectBaseObject):
-    max_masks: int
+    max_masks: Optional[int]
     rectangle_only: bool
 
 

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -129,6 +129,8 @@ class EventMetadata(ProtectBaseObject):
     mount_type: Optional[MountType]
     status: Optional[SensorStatusType]
     alarm_type: Optional[str]
+    device_id: Optional[str]
+    mac: Optional[str]
 
     _collapse_keys: ClassVar[SetStr] = {
         "lightId",
@@ -142,6 +144,8 @@ class EventMetadata(ProtectBaseObject):
         "mountType",
         "status",
         "alarmType",
+        "deviceId",
+        "mac",
     }
 
     @classmethod

--- a/pyunifiprotect/data/websocket.py
+++ b/pyunifiprotect/data/websocket.py
@@ -32,6 +32,7 @@ class WSPacketFrameHeader:
 class WSAction(str, enum.Enum):
     ADD = "add"
     UPDATE = "update"
+    REMOVE = "remove"
 
 
 @dataclass
@@ -39,7 +40,7 @@ class WSSubscriptionMessage:
     action: WSAction
     new_update_id: UUID
     changed_data: Dict[str, Any]
-    new_obj: ProtectModelWithId
+    new_obj: Optional[ProtectModelWithId] = None
     old_obj: Optional[ProtectModelWithId] = None
 
 

--- a/pyunifiprotect/websocket.py
+++ b/pyunifiprotect/websocket.py
@@ -64,7 +64,6 @@ class Websocket:
             _LOGGER.exception("Error from Websocket: %s", msg.data)
             return False
 
-        _LOGGER.debug("Recieved WS message. Sending to %s subscribers...", len(self._ws_subscriptions))
         for sub in self._ws_subscriptions:
             try:
                 sub(msg)
@@ -138,7 +137,6 @@ class Websocket:
             await asyncio.sleep(sleep_time)
 
     async def _reset_timeout(self) -> None:
-        _LOGGER.debug("WS timeout reset")
         self._timeout = time.monotonic() + self.timeout_interval
 
         if self._timer_task is None:


### PR DESCRIPTION
* Cleans up some no longer necessary and spammy WS debug messages
* Makes a few more fields optional (all from unadopted devices)
* Add support for "remove" WS messages so the full adopt/unadopt lifecycle can be subscribed to.
    * This requires a backing change to the schema of `WSSubscriptionMessage` as `new_obj` can now be `None` for remove packets

The "lifecycle" of a device looks like the following:

* **Device Discovered** - WS packet add -> {model}
* **Device Adopted** - WS packet add -> event[deviceAdopted] with metadata of the `device_id` referencing previously discovered device 
* **Device Unadopted** - WS packet add -> event[deviceUnadopted], followed by WS packet remove -> {model}
