### PR TITLE
Fixes copying update_lock

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -30,7 +30,7 @@ black==22.3.0
     # via pyunifiprotect (setup.cfg)
 build==0.8.0
     # via pyunifiprotect (setup.cfg)
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via aiohttp
 click==8.1.3
     # via
@@ -142,7 +142,7 @@ pygments==2.12.0
     # via ipython
 pyjwt==2.4.0
     # via pyunifiprotect (setup.cfg)
-pylint==2.14.2
+pylint==2.14.3
     # via
     #   pylint-strict-informational
     #   pyunifiprotect (setup.cfg)
@@ -202,7 +202,7 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.11.0
     # via pylint
-traitlets==5.2.2.post1
+traitlets==5.3.0
     # via
     #   ipython
     #   matplotlib-inline
@@ -210,7 +210,7 @@ typer==0.4.1
     # via pyunifiprotect (setup.cfg)
 types-aiofiles==0.8.8
     # via pyunifiprotect (setup.cfg)
-types-pillow==9.0.19
+types-pillow==9.0.20
     # via pyunifiprotect (setup.cfg)
 types-pytz==2021.3.8
     # via pyunifiprotect (setup.cfg)

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -52,9 +52,8 @@ if TYPE_CHECKING:
     from pyunifiprotect.data.nvr import Event
     from pyunifiprotect.data.user import User
 
+
 ProtectObject = TypeVar("ProtectObject", bound="ProtectBaseObject")
-
-
 RECENT_EVENT_MAX = timedelta(seconds=30)
 EVENT_PING_INTERVAL = timedelta(seconds=3)
 _LOGGER = logging.getLogger(__name__)

--- a/pyunifiprotect/data/base.py
+++ b/pyunifiprotect/data/base.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
 import logging
@@ -44,15 +45,16 @@ from pyunifiprotect.utils import (
 )
 
 if TYPE_CHECKING:
-    from pydantic.typing import DictStrAny, SetStr
+    from pydantic.typing import AbstractSetIntStr, DictStrAny, MappingIntStrAny, SetStr
 
     from pyunifiprotect.api import ProtectApiClient
     from pyunifiprotect.data.devices import Bridge
     from pyunifiprotect.data.nvr import Event
     from pyunifiprotect.data.user import User
 
-
 ProtectObject = TypeVar("ProtectObject", bound="ProtectBaseObject")
+
+
 RECENT_EVENT_MAX = timedelta(seconds=30)
 EVENT_PING_INTERVAL = timedelta(seconds=3)
 _LOGGER = logging.getLogger(__name__)
@@ -146,6 +148,27 @@ class ProtectBaseObject(BaseModel):
         obj._api = api  # pylint: disable=protected-access
 
         return obj  # type: ignore
+
+    def copy(
+        self: ProtectObject,
+        *,
+        include: Union[AbstractSetIntStr, MappingIntStrAny] = None,  # type: ignore
+        exclude: Union[AbstractSetIntStr, MappingIntStrAny] = None,  # type: ignore
+        update: DictStrAny = None,  # type: ignore
+        deep: bool = False,
+    ) -> ProtectObject:
+        exclude = exclude or set()
+        if isinstance(exclude, Mapping):
+            exclude = dict(exclude)
+            exclude["_api"] = True
+        else:
+            exclude = set(exclude)
+            exclude.add("_api")
+
+        new_obj = super().copy(include=include, exclude=exclude, update=update, deep=deep)
+        new_obj._api = self._api  # pylint: disable=protected-access
+
+        return new_obj
 
     @classmethod
     def _get_excluded_changed_fields(cls) -> Set[str]:
@@ -494,7 +517,7 @@ class ProtectBaseObject(BaseModel):
         self._initial_data = self.dict(exclude=self._get_excluded_changed_fields())
         return self
 
-    def get_changed(self: ProtectObject) -> Dict[str, Any]:
+    def get_changed(self) -> Dict[str, Any]:
         return dict_diff(self._initial_data, self.dict())
 
     @property
@@ -571,6 +594,27 @@ class ProtectModelWithId(ProtectModel):
         obj._update_lock = update_lock or asyncio.Lock()  # pylint: disable=protected-access
 
         return obj
+
+    def copy(
+        self: ProtectObject,
+        *,
+        include: Union[AbstractSetIntStr, MappingIntStrAny] = None,  # type: ignore
+        exclude: Union[AbstractSetIntStr, MappingIntStrAny] = None,  # type: ignore
+        update: DictStrAny = None,  # type: ignore
+        deep: bool = False,
+    ) -> ProtectObject:
+        exclude = exclude or set()
+        if isinstance(exclude, Mapping):
+            exclude = dict(exclude)
+            exclude["_update_lock"] = True
+        else:
+            exclude = set(exclude)
+            exclude.add("_update_lock")
+
+        new_obj: ProtectModelWithId = super().copy(include=include, exclude=exclude, update=update, deep=deep)  # type: ignore
+        new_obj._update_lock = self._update_lock  # type: ignore  # pylint: disable=protected-access
+
+        return new_obj  # type: ignore
 
     @classmethod
     def _get_read_only_fields(cls) -> Set[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ attrs==21.4.0
     # via aiohttp
 backcall==0.2.0
     # via ipython
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via aiohttp
 click==8.1.3
     # via typer
@@ -78,7 +78,7 @@ stack-data==0.3.0
     # via ipython
 termcolor==1.1.0
     # via pyunifiprotect (setup.cfg)
-traitlets==5.2.2.post1
+traitlets==5.3.0
     # via
     #   ipython
     #   matplotlib-inline


### PR DESCRIPTION
I tried using `typing_extensions.Self`, but it kept raising errors about it not being a valid type. The error looks like it got fixed in 4.0.1, but still was having it in 4.2.0. 

This is a lot dirtier, but hopefully should be able to be cleaned up in the future once the Self stuff is actually fixed. 