### PR TITLE
Improve WS message processing

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -57,6 +57,15 @@ NEVER_RAN = -1000
 DEVICE_UPDATE_INTERVAL = 900
 # retry timeout for thumbnails/heatmaps
 RETRY_TIMEOUT = 10
+EA_WARNING = """
+You are running an Early Access version of UniFi Protect. Early Access versions of
+UniFi Protect are not supported for Home Asssitant. If you are using Home Asssitant
+and have an error, please report errors to https://github.com/briis/pyunifiprotect
+first. DO NOT REPORT EA ISSUES TO HOME ASSISTANT CORE.
+
+It is recommended you downgrade to a stable version.
+https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect.
+"""
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -551,9 +560,12 @@ class ProtectApiClient(BaseApiClient):
         bootstrap_updated = False
         if self._bootstrap is None or now - self._last_update > DEVICE_UPDATE_INTERVAL:
             bootstrap_updated = True
+            self._bootstrap = await self.get_bootstrap()
+            if self._last_update == NEVER_RAN and self._bootstrap.nvr.version.is_prerelease:
+                _LOGGER.warning(EA_WARNING)
+
             self._last_update = now
             self._last_update_dt = now_dt
-            self._bootstrap = await self.get_bootstrap()
 
         await self.async_connect_ws(force)
         active_ws = self.check_ws()

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -61,7 +61,7 @@ RETRY_TIMEOUT = 10
 EA_WARNING = """
 You are running version %s of UniFi Protect, which is an Early Access version. Early Access versions of UniFi Protect are not supported for Home Asssitant.
 
-If you are using Home Asssitant and have an error, please report errors to https://github.com/briis/pyunifiprotect first. DO NOT REPORT EA ISSUES TO HOME ASSISTANT CORE.
+If have an error, please report errors to https://github.com/briis/pyunifiprotect first. DO NOT REPORT EA ISSUES TO HOME ASSISTANT CORE.
 
 It is recommended you downgrade to a stable version. https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect.
 """

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -65,6 +65,13 @@ If you are using Home Asssitant and have an error, please report errors to https
 It is recommended you downgrade to a stable version. https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect.
 """
 
+try:
+    import homeasssitant  # pylint: disable=unused-import  # noqa  # type: ignore
+
+    IS_HA = True
+except ImportError:
+    IS_HA = False
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -559,7 +566,7 @@ class ProtectApiClient(BaseApiClient):
         if self._bootstrap is None or now - self._last_update > DEVICE_UPDATE_INTERVAL:
             bootstrap_updated = True
             self._bootstrap = await self.get_bootstrap()
-            if self._last_update == NEVER_RAN and self._bootstrap.nvr.version.is_prerelease:
+            if self._last_update == NEVER_RAN and IS_HA and self._bootstrap.nvr.version.is_prerelease:
                 _LOGGER.warning(EA_WARNING, self._bootstrap.nvr.version)
 
             self._last_update = now

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -38,6 +38,7 @@ from pyunifiprotect.data import (
     WSSubscriptionMessage,
     create_from_unifi_dict,
 )
+from pyunifiprotect.data.base import ProtectModelWithId
 from pyunifiprotect.data.devices import Chime
 from pyunifiprotect.data.types import IteratorCallback, ProgressCallback, RecordingMode
 from pyunifiprotect.exceptions import BadRequest, NotAuthorized, NvrError
@@ -821,8 +822,8 @@ class ProtectApiClient(BaseApiClient):
         return await self.api_request_obj(f"{model_type.value}s/{device_id}")
 
     async def get_device(
-        self, model_type: ModelType, device_id: str, expected_type: Optional[Type[ProtectModel]] = None
-    ) -> ProtectModel:
+        self, model_type: ModelType, device_id: str, expected_type: Optional[Type[ProtectModelWithId]] = None
+    ) -> ProtectModelWithId:
         """Gets a device give the device model_type and id, converted into Python object"""
         obj = create_from_unifi_dict(await self.get_device_raw(model_type, device_id), api=self)
 
@@ -831,7 +832,7 @@ class ProtectApiClient(BaseApiClient):
         if self.ignore_unadopted and isinstance(obj, ProtectAdoptableDeviceModel) and not obj.is_adopted:
             raise NvrError("Device is not adopted")
 
-        return obj
+        return cast(ProtectModelWithId, obj)
 
     async def get_nvr(self) -> NVR:
         """

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -66,7 +66,7 @@ It is recommended you downgrade to a stable version. https://www.home-assistant.
 """
 
 try:
-    import homeasssitant  # pylint: disable=unused-import  # noqa  # type: ignore
+    import homeasssitant  # type: ignore # pylint: disable=unused-import # noqa
 
     IS_HA = True
 except ImportError:

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -58,14 +58,11 @@ DEVICE_UPDATE_INTERVAL = 900
 # retry timeout for thumbnails/heatmaps
 RETRY_TIMEOUT = 10
 EA_WARNING = """
-You are running version {version} of UniFi Protect, which is an Early Access version.
-Early Access versions of UniFi Protect are not supported for Home Asssitant. If you
-are using Home Asssitant and have an error, please report errors to
-https://github.com/briis/pyunifiprotect first. DO NOT REPORT EA ISSUES TO HOME
-ASSISTANT CORE.
+You are running version %s of UniFi Protect, which is an Early Access version. Early Access versions of UniFi Protect are not supported for Home Asssitant.
 
-It is recommended you downgrade to a stable version.
-https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect.
+If you are using Home Asssitant and have an error, please report errors to https://github.com/briis/pyunifiprotect first. DO NOT REPORT EA ISSUES TO HOME ASSISTANT CORE.
+
+It is recommended you downgrade to a stable version. https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect.
 """
 
 
@@ -563,7 +560,7 @@ class ProtectApiClient(BaseApiClient):
             bootstrap_updated = True
             self._bootstrap = await self.get_bootstrap()
             if self._last_update == NEVER_RAN and self._bootstrap.nvr.version.is_prerelease:
-                _LOGGER.warning(EA_WARNING.format(version=self._bootstrap.nvr.version))
+                _LOGGER.warning(EA_WARNING, self._bootstrap.nvr.version)
 
             self._last_update = now
             self._last_update_dt = now_dt

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -58,10 +58,11 @@ DEVICE_UPDATE_INTERVAL = 900
 # retry timeout for thumbnails/heatmaps
 RETRY_TIMEOUT = 10
 EA_WARNING = """
-You are running an Early Access version of UniFi Protect. Early Access versions of
-UniFi Protect are not supported for Home Asssitant. If you are using Home Asssitant
-and have an error, please report errors to https://github.com/briis/pyunifiprotect
-first. DO NOT REPORT EA ISSUES TO HOME ASSISTANT CORE.
+You are running version {version} of UniFi Protect, which is an Early Access version.
+Early Access versions of UniFi Protect are not supported for Home Asssitant. If you
+are using Home Asssitant and have an error, please report errors to
+https://github.com/briis/pyunifiprotect first. DO NOT REPORT EA ISSUES TO HOME
+ASSISTANT CORE.
 
 It is recommended you downgrade to a stable version.
 https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect.
@@ -562,7 +563,7 @@ class ProtectApiClient(BaseApiClient):
             bootstrap_updated = True
             self._bootstrap = await self.get_bootstrap()
             if self._last_update == NEVER_RAN and self._bootstrap.nvr.version.is_prerelease:
-                _LOGGER.warning(EA_WARNING)
+                _LOGGER.warning(EA_WARNING.format(version=self._bootstrap.nvr.version)
 
             self._last_update = now
             self._last_update_dt = now_dt

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -563,7 +563,7 @@ class ProtectApiClient(BaseApiClient):
             bootstrap_updated = True
             self._bootstrap = await self.get_bootstrap()
             if self._last_update == NEVER_RAN and self._bootstrap.nvr.version.is_prerelease:
-                _LOGGER.warning(EA_WARNING.format(version=self._bootstrap.nvr.version)
+                _LOGGER.warning(EA_WARNING.format(version=self._bootstrap.nvr.version))
 
             self._last_update = now
             self._last_update_dt = now_dt

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -7,6 +7,7 @@ from http.cookies import Morsel
 from ipaddress import IPv4Address
 import logging
 from pathlib import Path
+import sys
 import time
 from typing import Any, Callable, Dict, List, Optional, Set, Type, Union, cast
 from urllib.parse import urljoin
@@ -64,13 +65,7 @@ If you are using Home Asssitant and have an error, please report errors to https
 
 It is recommended you downgrade to a stable version. https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect.
 """
-
-try:
-    import homeasssitant  # type: ignore # pylint: disable=unused-import # noqa
-
-    IS_HA = True
-except ImportError:
-    IS_HA = False
+IS_HA = "homeassistant" in sys.modules
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -501,7 +501,7 @@ class Bootstrap(ProtectBaseObject):
             _LOGGER.warning("Failed to refresh device: %s %s", model_type, device_id)
             return
 
-        if model_type == ModelType.NVR:
+        if isinstance(device, NVR):
             self.nvr = device
         else:
             devices = getattr(self, f"{model_type.value}s")

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -1,6 +1,7 @@
 """UniFi Protect Bootstrap."""
 from __future__ import annotations
 
+import asyncio
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
@@ -8,7 +9,8 @@ import logging
 from typing import Any, Dict, List, Optional, Set, Tuple, cast
 from uuid import UUID
 
-from pydantic.fields import PrivateAttr
+from aiohttp.client_exceptions import ServerDisconnectedError
+from pydantic import PrivateAttr, ValidationError
 
 from pyunifiprotect.data.base import (
     RECENT_EVENT_MAX,
@@ -36,6 +38,7 @@ from pyunifiprotect.data.websocket import (
     WSPacket,
     WSSubscriptionMessage,
 )
+from pyunifiprotect.exceptions import ClientError
 from pyunifiprotect.utils import utc_now
 
 _LOGGER = logging.getLogger(__name__)
@@ -380,9 +383,11 @@ class Bootstrap(ProtectBaseObject):
             self._create_stat(packet, [], True)
             return None
 
-        key = model_type + "s"
+        key = f"{model_type}s"
         devices = getattr(self, key)
         if action["id"] in devices:
+            if action["id"] not in devices:
+                raise ValueError(f"Unknown device update for {model_type}: { action['id']}")
             obj: ProtectModelWithId = devices[action["id"]]
             data = obj.unifi_dict_to_dict(data)
             old_obj = obj.copy()
@@ -452,15 +457,47 @@ class Bootstrap(ProtectBaseObject):
             self._create_stat(packet, [], True)
             return None
 
-        if action["action"] == "add":
-            return self._process_add_packet(packet, data)
+        try:
+            if action["action"] == "add":
+                return self._process_add_packet(packet, data)
 
-        if action["action"] == "update":
-            if action["modelKey"] == ModelType.NVR.value:
-                return self._process_nvr_update(packet, data, ignore_stats)
-            if action["modelKey"] in ModelType.bootstrap_models() or action["modelKey"] == ModelType.EVENT.value:
-                return self._process_device_update(packet, action, data, ignore_stats)
-            _LOGGER.debug("Unexpected bootstrap model type for update: %s", action["modelKey"])
+            if action["action"] == "update":
+                if action["modelKey"] == ModelType.NVR.value:
+                    return self._process_nvr_update(packet, data, ignore_stats)
+                if action["modelKey"] in ModelType.bootstrap_models() or action["modelKey"] == ModelType.EVENT.value:
+                    return self._process_device_update(packet, action, data, ignore_stats)
+                _LOGGER.debug("Unexpected bootstrap model type deviceadoptedfor update: %s", action["modelKey"])
+        except (ValidationError, ValueError) as err:
+            self._handle_ws_error(action, err)
 
         self._create_stat(packet, [], True)
         return None
+
+    def _handle_ws_error(self, action: Dict[str, Any], err: Exception) -> None:
+        msg = ""
+        if action["modelKey"] == "event":
+            msg = f"Validation error processing event: {action['id']}. Ignoring event."
+        else:
+            try:
+                model_type = ModelType(action["modelKey"])
+                device_id = action["id"]
+                asyncio.create_task(self.refresh_device(model_type, device_id))
+            except (ValueError, IndexError):
+                msg = f"{action['action']} packet caused invalid state. Unable to refresh device."
+            else:
+                msg = f"{action['action']} packet caused invalid state. Refreshing device: {model_type} {device_id}"
+
+            _LOGGER.warning("%s Error: %s", msg, err)
+
+    async def refresh_device(self, model_type: ModelType, device_id: str) -> None:
+        """Refresh a device in the bootstrap."""
+
+        try:
+            device = await self.api.get_device(model_type, device_id)
+        except (ValidationError, TimeoutError, ClientError, ServerDisconnectedError):
+            _LOGGER.warning("Failed to refresh device: %s %s", model_type, device_id)
+            return
+
+        devices = getattr(self, f"{model_type.value}s")
+        devices[device.id] = device
+        _LOGGER.debug("Successfully refresh device: %s %s", model_type, device_id)

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -493,11 +493,17 @@ class Bootstrap(ProtectBaseObject):
         """Refresh a device in the bootstrap."""
 
         try:
-            device = await self.api.get_device(model_type, device_id)
+            if model_type == ModelType.NVR:
+                device = await self.api.get_nvr()
+            else:
+                device = await self.api.get_device(model_type, device_id)
         except (ValidationError, TimeoutError, ClientError, ServerDisconnectedError):
             _LOGGER.warning("Failed to refresh device: %s %s", model_type, device_id)
             return
 
-        devices = getattr(self, f"{model_type.value}s")
-        devices[device.id] = device
+        if model_type == ModelType.NVR:
+            self.nvr = device
+        else:
+            devices = getattr(self, f"{model_type.value}s")
+            devices[device.id] = device
         _LOGGER.debug("Successfully refresh device: %s %s", model_type, device_id)

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -494,7 +494,7 @@ class Bootstrap(ProtectBaseObject):
 
         try:
             if model_type == ModelType.NVR:
-                device = await self.api.get_nvr()
+                device: ProtectModelWithId = await self.api.get_nvr()
             else:
                 device = await self.api.get_device(model_type, device_id)
         except (ValidationError, TimeoutError, ClientError, ServerDisconnectedError):

--- a/pyunifiprotect/data/bootstrap.py
+++ b/pyunifiprotect/data/bootstrap.py
@@ -486,8 +486,7 @@ class Bootstrap(ProtectBaseObject):
                 msg = f"{action['action']} packet caused invalid state. Unable to refresh device."
             else:
                 msg = f"{action['action']} packet caused invalid state. Refreshing device: {model_type} {device_id}"
-
-            _LOGGER.warning("%s Error: %s", msg, err)
+        _LOGGER.debug("%s Error: %s", msg, err)
 
     async def refresh_device(self, model_type: ModelType, device_id: str) -> None:
         """Refresh a device in the bootstrap."""

--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -685,7 +685,7 @@ class Camera(ProtectMotionDeviceModel):
     chime_duration: ChimeDuration
     last_ring: Optional[datetime]
     is_live_heatmap_enabled: bool
-    anonymous_device_id: UUID
+    anonymous_device_id: Optional[UUID]
     event_stats: CameraEventStats
     video_reconfiguration_in_progress: bool
     channels: List[CameraChannel]

--- a/pyunifiprotect/data/nvr.py
+++ b/pyunifiprotect/data/nvr.py
@@ -692,7 +692,7 @@ class NVR(ProtectDeviceModel):
     enable_crash_reporting: bool
     disable_audio: bool
     analytics_data: AnalyticsOption
-    anonymous_device_id: UUID
+    anonymous_device_id: Optional[UUID]
     camera_utilization: int
     is_recycling: bool
     avg_motions: List[float]


### PR DESCRIPTION
* Ignore update packets for devices that do not exist
* Catch validation errors for WS packets and trigger a manual refresh of the device in the bootstrap (or ignore them for non-adoptable devices)
* Adds warning log message for using an EA version of UniFi Protect in Home Assistant