### PR TITLE
Handle auth failures when time is not perfectly in sync

### DIFF
--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -395,7 +395,7 @@ class BaseApiClient:
         """Update the last token cookie."""
         if (token_cookie := response.cookies.get("TOKEN")) and token_cookie != self._last_token_cookie:
             self._last_token_cookie = token_cookie
-            self._last_token_cookie_decode = decode_token_cookie(token_cookie)
+            self._last_token_cookie_decode = None
 
     def is_authenticated(self) -> bool:
         """Check to see if we are already authenticated."""
@@ -405,8 +405,12 @@ class BaseApiClient:
         if self._is_authenticated is False:
             return False
 
-        if not self._last_token_cookie_decode:
+        if self._last_token_cookie is None:
             return False
+
+        # Lazy decode the token cookie
+        if self._last_token_cookie and self._last_token_cookie_decode is None:
+            self._last_token_cookie_decode = decode_token_cookie(self._last_token_cookie)
 
         if self._last_token_cookie_decode.get("exp") < (time.time() + TOKEN_COOKIE_MAX_EXP_SECONDS):
             return False

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -412,7 +412,10 @@ class BaseApiClient:
         if self._last_token_cookie and self._last_token_cookie_decode is None:
             self._last_token_cookie_decode = decode_token_cookie(self._last_token_cookie)
 
-        if self._last_token_cookie_decode.get("exp") < (time.time() + TOKEN_COOKIE_MAX_EXP_SECONDS):
+        if "exp" not in self._last_token_cookie_decode:
+            return False
+
+        if self._last_token_cookie_decode["exp"] < (time.time() + TOKEN_COOKIE_MAX_EXP_SECONDS):
             return False
 
         return True

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -412,7 +412,7 @@ class BaseApiClient:
         if self._last_token_cookie and self._last_token_cookie_decode is None:
             self._last_token_cookie_decode = decode_token_cookie(self._last_token_cookie)
 
-        if "exp" not in self._last_token_cookie_decode:
+        if self._last_token_cookie_decode is None or "exp" not in self._last_token_cookie_decode:
             return False
 
         token_expires_at = self._last_token_cookie_decode["exp"]

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -233,18 +233,19 @@ class BaseApiClient:
             try:
                 req_context = session.request(method, url, headers=headers, **kwargs)
                 response = await req_context.__aenter__()  # pylint: disable=unnecessary-dunder-call
+
                 if token_cookie := response.cookies.get("TOKEN"):
                     self._last_token_cookie = token_cookie
 
-                try:
-                    _LOGGER.debug("%s %s %s", response.status, response.content_type, response)
-                    if auto_close:
+                if auto_close:
+                    try:
+                        _LOGGER.debug("%s %s %s", response.status, response.content_type, response)
                         response.release()
-                except Exception:
-                    # make sure response is released
-                    response.release()
-                    # re-raise exception
-                    raise
+                    except Exception:
+                        # make sure response is released
+                        response.release()
+                        # re-raise exception
+                        raise
 
                 if attempt == 0 and require_auth and response.status in (401, 403):
                     await self.authenticate()

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -240,16 +240,16 @@ class BaseApiClient:
                     _LOGGER.debug("%s %s %s", response.status, response.content_type, response)
                     if auto_close:
                         response.release()
-                    return response
                 except Exception:
                     # make sure response is released
                     response.release()
                     # re-raise exception
                     raise
 
-                if require_auth and response.status in (401, 403):
+                if attempt == 0 and require_auth and response.status in (401, 403):
                     await self.authenticate()
                     continue
+                return response
             except aiohttp.ServerDisconnectedError as err:
                 # If the server disconnected, try again
                 # since HTTP/1.1 allows the server to disconnect

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -415,7 +415,10 @@ class BaseApiClient:
         if "exp" not in self._last_token_cookie_decode:
             return False
 
-        if self._last_token_cookie_decode["exp"] < (time.time() + TOKEN_COOKIE_MAX_EXP_SECONDS):
+        token_expires_at = self._last_token_cookie_decode["exp"]
+        max_expire_time = time.time() + TOKEN_COOKIE_MAX_EXP_SECONDS
+
+        if token_expires_at < max_expire_time:
             return False
 
         return True

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -408,7 +408,7 @@ class BaseApiClient:
         if not self._last_token_cookie_decode:
             return False
 
-        if self._last_token_cookie_decode.get("exp") > time.time() + TOKEN_COOKIE_MAX_EXP_SECONDS:
+        if self._last_token_cookie_decode.get("exp") < (time.time() + TOKEN_COOKIE_MAX_EXP_SECONDS):
             return False
 
         return True

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -261,6 +261,9 @@ class BaseApiClient:
             except client_exceptions.ClientError as err:
                 raise NvrError(f"Error requesting data from {self._host}: {err}") from err
 
+        # should never happen
+        raise NvrError(f"Error requesting data from {self._host}")
+
     async def api_request_raw(
         self,
         url: str,

--- a/pyunifiprotect/api.py
+++ b/pyunifiprotect/api.py
@@ -138,7 +138,7 @@ class BaseApiClient:
     _last_update: float = NEVER_RAN
     _last_ws_status: bool = False
     _last_token_cookie: Morsel[str] | None = None
-    _last_token_cookie_decode: Optional[float] = None
+    _last_token_cookie_decode: Optional[Dict[str, Any]] = None
     _session: Optional[aiohttp.ClientSession] = None
 
     headers: Optional[Dict[str, str]] = None

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -385,7 +385,7 @@ async def profile_ws(
         print_ws_stat_summary(protect.bootstrap.ws_stats, output=print_output)
 
 
-def decode_token_cookie(token_cookie: Morsel[str] | None) -> dict[str, Any] | None:
+def decode_token_cookie(token_cookie: Morsel[str]) -> Dict[str, Any] | None:
     """Decode a token cookie if it is still valid."""
     try:
         return jwt.decode(

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -385,7 +385,7 @@ async def profile_ws(
         print_ws_stat_summary(protect.bootstrap.ws_stats, output=print_output)
 
 
-def decode_token_cookie(token_cookie: Morsel[str] | None) -> dict[str, Any]:
+def decode_token_cookie(token_cookie: Morsel[str] | None) -> dict[str, Any] | None:
     """Decode a token cookie if it is still valid."""
     try:
         return jwt.decode(

--- a/pyunifiprotect/utils.py
+++ b/pyunifiprotect/utils.py
@@ -385,19 +385,16 @@ async def profile_ws(
         print_ws_stat_summary(protect.bootstrap.ws_stats, output=print_output)
 
 
-def token_cookie_is_valid(token_cookie: Morsel[str] | None) -> bool:
-    """Check if a token cookie is still valid."""
-    if token_cookie is None:
-        return False
+def decode_token_cookie(token_cookie: Morsel[str] | None) -> dict[str, Any]:
+    """Decode a token cookie if it is still valid."""
     try:
-        jwt.decode(
+        return jwt.decode(
             token_cookie.value,
             options={"verify_signature": False, "verify_exp": True},
         )
     except jwt.ExpiredSignatureError:
         _LOGGER.debug("Authentication token has expired.")
-        return False
+        return None
     except Exception as broad_ex:  # pylint: disable=broad-except
         _LOGGER.debug("Authentication token decode error: %s", broad_ex)
-        return False
-    return True
+        return None


### PR DESCRIPTION
We were seeing auth errors when the time wasn't perfectly in sync.

We now have a 60s safety to ensure we get a new token

We also only get one at time in case there are many requests that need one.

We now also handle the case were the http server disconnects.