### PR TITLE
Fixes ValueError when camera has unknown smart type

### DIFF
--- a/pyunifiprotect/data/devices.py
+++ b/pyunifiprotect/data/devices.py
@@ -652,6 +652,19 @@ class FeatureFlags(ProtectBaseObject):
     # hotplug
 
     @classmethod
+    def unifi_dict_to_dict(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        if "smartDetectTypes" in data:
+            types = []
+            for smart_type in data.pop("smartDetectTypes"):
+                try:
+                    types.append(SmartDetectObjectType(smart_type))
+                except ValueError:
+                    _LOGGER.warning("Unknown smart detect type: %s", smart_type)
+            data["smartDetectTypes"] = types
+
+        return super().unifi_dict_to_dict(data)
+
+    @classmethod
     def _get_unifi_remaps(cls) -> Dict[str, str]:
         return {**super()._get_unifi_remaps(), "hasAutoICROnly": "hasAutoIcrOnly"}
 

--- a/tests/data/test_camera.py
+++ b/tests/data/test_camera.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access
 
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Dict, Optional
 from unittest.mock import Mock, patch
 
 from pydantic.error_wrappers import ValidationError
@@ -921,3 +921,15 @@ async def test_camera_set_privacy(
             assert camera_obj.is_privacy_on
         else:
             assert not camera_obj.is_privacy_on
+
+
+@pytest.mark.skipif(not TEST_CAMERA_EXISTS, reason="Missing testdata")
+@pytest.mark.asyncio
+async def test_camera_unknown_smart(camera: Optional[Dict[str, str]]):
+    if camera is None:
+        pytest.skip("No camera obj found")
+
+    camera["featureFlags"]["smartDetectTypes"] = ["alrmSmoke"]
+
+    camera_obj = Camera.from_unifi_dict(None, **camera)
+    assert camera_obj.feature_flags.smart_detect_types == []


### PR DESCRIPTION
Should finally fix the fatal crash when an unknown smart detection type is provided by UniFi Protect.